### PR TITLE
Ajout de la récupération de compte (mot de passe oublié)

### DIFF
--- a/Lern-API.Tests/Controllers/UsersControllerShould.cs
+++ b/Lern-API.Tests/Controllers/UsersControllerShould.cs
@@ -152,9 +152,49 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public void Return_Current_User(Mock<IUserService> service, User user)
+        public void Return_OK_On_Forgotten_Password(IUserService service, string login)
         {
-            var controller = TestSetup.SetupController<UsersController>(service.Object).SetupSession(user);
+            var controller = TestSetup.SetupController<UsersController>(service);
+
+            var result = controller.ForgottenPassword(login);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<OkResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public void Return_OK_On_Valid_Forgotten_Password_Definition(Mock<IUserService> service, ForgottenPasswordRequest request)
+        {
+            service.Setup(x => x.DefineForgottenPassword(request.Token, request.Password, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            var controller = TestSetup.SetupController<UsersController>(service.Object);
+
+            var result = controller.ForgottenPasswordDefinition(request);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<OkResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public void Return_400_On_Valid_Forgotten_Password_Definition(Mock<IUserService> service, ForgottenPasswordRequest request)
+        {
+            service.Setup(x => x.DefineForgottenPassword(request.Token, request.Password, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            var controller = TestSetup.SetupController<UsersController>(service.Object);
+
+            var result = controller.ForgottenPasswordDefinition(request);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public void Return_Current_User(IUserService service, User user)
+        {
+            var controller = TestSetup.SetupController<UsersController>(service).SetupSession(user);
 
             var result = controller.Whoami();
 

--- a/Lern-API.Tests/Lern-API.Tests.csproj
+++ b/Lern-API.Tests/Lern-API.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">

--- a/Lern-API.Tests/Services/ServiceShould.cs
+++ b/Lern-API.Tests/Services/ServiceShould.cs
@@ -21,7 +21,7 @@ namespace Lern_API.Tests.Services
         public async Task Get_All_Entities(List<User> entities)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddRangeAsync(entities);
             await context.SaveChangesAsync();
@@ -36,7 +36,7 @@ namespace Lern_API.Tests.Services
         public async Task Get_Single_Entity_Or_Null(List<User> entities, User target)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddRangeAsync(entities);
             await context.Users.AddAsync(target);
@@ -54,7 +54,7 @@ namespace Lern_API.Tests.Services
         public async Task Create_Entity(UserRequest request)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             var result = await service.Create(request);
 
@@ -67,7 +67,7 @@ namespace Lern_API.Tests.Services
         public async Task Update_Entity(User entity, UserRequest request)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddAsync(entity);
             await context.SaveChangesAsync();
@@ -83,7 +83,7 @@ namespace Lern_API.Tests.Services
         public async Task Delete_Entity(List<User> entities, User target)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddRangeAsync(entities);
             await context.Users.AddAsync(target);
@@ -100,7 +100,7 @@ namespace Lern_API.Tests.Services
         public async Task Return_False_On_Invalid_Delete(List<User> entities)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddRangeAsync(entities);
             await context.SaveChangesAsync();
@@ -115,7 +115,7 @@ namespace Lern_API.Tests.Services
         public async Task Check_If_Entity_Exists(List<User> entities, User target)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             await context.Users.AddRangeAsync(entities);
             await context.Users.AddAsync(target);
@@ -133,7 +133,7 @@ namespace Lern_API.Tests.Services
         public async Task Execute_Custom_Async_Transactions(User entity)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             var result = await service.ExecuteTransaction(async set => await set.AddAsync(entity));
 
@@ -146,7 +146,7 @@ namespace Lern_API.Tests.Services
         public async Task Execute_Custom_Transactions(User entity)
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             var result = await service.ExecuteTransaction(set => set.Add(entity));
 
@@ -158,7 +158,7 @@ namespace Lern_API.Tests.Services
         public async Task Return_Null_On_Failed_Transaction()
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             var result = await service.ExecuteTransaction(set =>
             {
@@ -176,7 +176,7 @@ namespace Lern_API.Tests.Services
         public async Task Return_Null_On_Failed_Async_Transaction()
         {
             var context = TestSetup.SetupContext();
-            var service = new Service<User, UserRequest>(context);
+            var service = new DatabaseService<User, UserRequest>(context);
 
             var result = await service.ExecuteTransaction(async set =>
             {

--- a/Lern-API.Tests/Services/UserServiceShould.cs
+++ b/Lern-API.Tests/Services/UserServiceShould.cs
@@ -50,7 +50,7 @@ namespace Lern_API.Tests.Services
             var user = new User
             {
                 Id = Guid.NewGuid(),
-                Email = request.Login,
+                Email = request.Login.ToLowerInvariant(),
                 Password = BCrypt.Net.BCrypt.EnhancedHashPassword(request.Password)
             };
 

--- a/Lern-API.Tests/Services/UserServiceShould.cs
+++ b/Lern-API.Tests/Services/UserServiceShould.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Helpers.JWT;
+using Lern_API.Helpers.Models;
 using Lern_API.Models;
 using Lern_API.Services;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
+using Moq;
 using Xunit;
 
 namespace Lern_API.Tests.Services
@@ -14,7 +20,7 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_User_By_Nickname(LoginRequest request)
+        public async Task Get_User_By_Nickname(IMailService mailService, LoginRequest request)
         {
             var context = TestSetup.SetupContext();
             
@@ -28,7 +34,7 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Login(request);
 
             result.Should().NotBeNull();
@@ -37,7 +43,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_User_By_Email(LoginRequest request)
+        public async Task Get_User_By_Email(IMailService mailService, LoginRequest request)
         {
             var context = TestSetup.SetupContext();
             
@@ -51,7 +57,7 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Login(request);
 
             result.Should().NotBeNull();
@@ -60,7 +66,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Return_Null_When_Login_Does_Not_Exist(LoginRequest request, string nickname, string email)
+        public async Task Return_Null_When_Login_Does_Not_Exist(IMailService mailService, LoginRequest request, string nickname, string email)
         {
             var context = TestSetup.SetupContext();
             
@@ -75,7 +81,7 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Login(request);
 
             result.Should().BeNull();
@@ -83,7 +89,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Return_Null_When_Password_Does_Not_Match(LoginRequest request, string fakePassword)
+        public async Task Return_Null_When_Password_Does_Not_Match(IMailService mailService, LoginRequest request, string fakePassword)
         {
             var context = TestSetup.SetupContext();
             
@@ -98,7 +104,7 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Login(request);
 
             result.Should().BeNull();
@@ -106,13 +112,13 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Encrypt_Password_On_Create(UserRequest request, string password)
+        public async Task Encrypt_Password_On_Create(IMailService mailService, UserRequest request, string password)
         {
             request.Password = password;
 
             var context = TestSetup.SetupContext();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Create(request);
 
             result.Should().NotBeNull();
@@ -121,7 +127,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Encrypt_Password_On_Update(Guid id, User user, UserRequest request, string password)
+        public async Task Encrypt_Password_On_Update(IMailService mailService, Guid id, User user, UserRequest request, string password)
         {
             user.Id = id;
             request.Password = password;
@@ -131,7 +137,7 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Update(id, request);
 
             result.Should().NotBeNull();
@@ -140,7 +146,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Ignore_Null_Password_On_Update(Guid id, User user, UserRequest request, string password)
+        public async Task Ignore_Null_Password_On_Update(IMailService mailService, Guid id, User user, UserRequest request, string password)
         {
             user.Id = id;
             user.Password = password;
@@ -151,11 +157,110 @@ namespace Lern_API.Tests.Services
             await context.Users.AddAsync(user);
             await context.SaveChangesAsync();
 
-            var service = new UserService(context);
+            var service = new UserService(context, mailService);
             var result = await service.Update(id, request);
 
             result.Should().NotBeNull();
             result.Password.Should().Be(password);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Send_Forgotten_Password_Email_Using_Nickname(Mock<IMailService> mailService, User user, Uri url)
+        {
+            mailService.Setup(x => x.SendEmailAsync(user, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<It.IsAnyType>(), It.IsAny<CancellationToken>()));
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.SaveChangesAsync();
+
+            var service = new UserService(context, mailService.Object);
+            await service.ForgottenPassword(user.Nickname, url.AbsolutePath);
+            
+            mailService.VerifyAll();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Send_Forgotten_Password_Email_Using_Email_Address(Mock<IMailService> mailService, User user, Uri url)
+        {
+            mailService.Setup(x => x.SendEmailAsync(user, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<It.IsAnyType>(), It.IsAny<CancellationToken>()));
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.SaveChangesAsync();
+
+            var service = new UserService(context, mailService.Object);
+            await service.ForgottenPassword(user.Email, url.AbsolutePath);
+            
+            mailService.VerifyAll();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Always_Wait_Two_Seconds_On_Forgotten_Password(IMailService mailService, User user, Uri url)
+        {
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.SaveChangesAsync();
+
+            var service = new UserService(context, mailService);
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            await service.ForgottenPassword(user.Email, url.AbsolutePath);
+
+            stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Define_Password_Using_Valid_Token(IMailService mailService, User user, string password)
+        {
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.SaveChangesAsync();
+
+            var service = new UserService(context, mailService);
+
+            var token = user.GenerateForgottenPasswordToken();
+
+            var result = await service.DefineForgottenPassword(token, password);
+
+            result.Should().BeTrue();
+            BCrypt.Net.BCrypt.EnhancedVerify(password, context.Users.First().Password).Should().BeTrue();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Not_Define_Password_Using_Invalid_Token(IMailService mailService, User user, Guid invalidId, string invalidToken, string password)
+        {
+            var initialPassword = user.Password;
+
+            var invalidUser = new User();
+            invalidUser.CloneFrom(user);
+            invalidUser.Id = invalidId;
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.SaveChangesAsync();
+
+            var service = new UserService(context, mailService);
+
+            var token = invalidUser.GenerateForgottenPasswordToken();
+
+            var invalidUserResult = await service.DefineForgottenPassword(token, password);
+            var invalidTokenResult = await service.DefineForgottenPassword(invalidToken, password);
+
+            invalidUserResult.Should().BeFalse();
+            invalidTokenResult.Should().BeFalse();
+            context.Users.First().Password.Should().Be(initialPassword);
         }
     }
 }

--- a/Lern-API/Controllers/UsersController.cs
+++ b/Lern-API/Controllers/UsersController.cs
@@ -149,7 +149,7 @@ namespace Lern_API.Controllers
         /// <param name="request">The token sent by email along with the new password</param>
         /// <returns></returns>
         [HttpPost("/api/ForgottenPassword")]
-        public async Task<IActionResult> ForgottenPasswordDefinition(ForgottenPasswordDefinitionRequest request)
+        public async Task<IActionResult> ForgottenPasswordDefinition(ForgottenPasswordRequest request)
         {
             var result = await _users.DefineForgottenPassword(request.Token, request.Password, HttpContext.RequestAborted);
 

--- a/Lern-API/Controllers/UsersController.cs
+++ b/Lern-API/Controllers/UsersController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.DataTransferObjects.Responses;
+using Lern_API.Helpers.Context;
 using Lern_API.Helpers.JWT;
 using Lern_API.Models;
 using Lern_API.Services;
@@ -123,6 +124,41 @@ namespace Lern_API.Controllers
             return response;
         }
 
+        /// <summary>
+        /// Send an email with a password definition link to the user associated to the given nickname or email address.
+        /// </summary>
+        /// <remarks>
+        /// This route will always take more than 2 seconds to complete, to avoid timing attacks.
+        /// </remarks>
+        /// <param name="login">The nickname or the email address of the user</param>
+        /// <response code="200">This route always sends an empty OK response</response>
+        [HttpGet("/api/ForgottenPassword")]
+        public async Task<IActionResult> ForgottenPassword([FromQuery] string login)
+        {
+            await _users.ForgottenPassword(login, HttpContext.GetBaseUrl(), HttpContext.RequestAborted);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Define a new password for the user associated to the given token.
+        /// </summary>
+        /// <remarks>
+        /// To get a valid token, please use the <c>/api/ForgottenPassword</c> route
+        /// </remarks>
+        /// <param name="request">The token sent by email along with the new password</param>
+        /// <returns></returns>
+        [HttpPost("/api/ForgottenPassword")]
+        public async Task<IActionResult> ForgottenPasswordDefinition(ForgottenPasswordDefinitionRequest request)
+        {
+            var result = await _users.DefineForgottenPassword(request.Token, request.Password, HttpContext.RequestAborted);
+
+            if (!result)
+                return BadRequest();
+
+            return Ok();
+        }
+        
         /// <summary>
         /// Returns the currently logged in user
         /// </summary>

--- a/Lern-API/DataTransferObjects/Requests/AnswerRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/AnswerRequest.cs
@@ -21,7 +21,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class AnswerRequestValidator : AbstractValidator<AnswerRequest>
     {
-        public AnswerRequestValidator(IService<Question, QuestionRequest> questionService)
+        public AnswerRequestValidator(IDatabaseService<Question, QuestionRequest> questionService)
         {
             RuleFor(x => x.QuestionId).NotNull().MustExistInDatabase(questionService);
             RuleFor(x => x.Text).NotEmpty().Length(3, 300);

--- a/Lern-API/DataTransferObjects/Requests/ArticleRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ArticleRequest.cs
@@ -23,7 +23,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class ArticleRequestValidator : AbstractValidator<ArticleRequest>
     {
-        public ArticleRequestValidator(IService<Concept, ConceptRequest> conceptService)
+        public ArticleRequestValidator(IDatabaseService<Concept, ConceptRequest> conceptService)
         {
             RuleFor(x => x.ConceptId).NotNull().MustExistInDatabase(conceptService);
             RuleFor(x => x.Title).NotEmpty().Length(3, 150);

--- a/Lern-API/DataTransferObjects/Requests/ConceptRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ConceptRequest.cs
@@ -23,7 +23,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class ConceptRequestValidator : AbstractValidator<ConceptRequest>
     {
-        public ConceptRequestValidator(IService<Module, ModuleRequest> moduleService)
+        public ConceptRequestValidator(IDatabaseService<Module, ModuleRequest> moduleService)
         {
             RuleFor(x => x.ModuleId).NotNull().MustExistInDatabase(moduleService);
             RuleFor(x => x.Title).NotNull().Length(3, 50);

--- a/Lern-API/DataTransferObjects/Requests/CourseRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/CourseRequest.cs
@@ -25,7 +25,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class CourseRequestValidator : AbstractValidator<CourseRequest>
     {
-        public CourseRequestValidator(IService<Concept, ConceptRequest> conceptService)
+        public CourseRequestValidator(IDatabaseService<Concept, ConceptRequest> conceptService)
         {
             RuleFor(x => x.ConceptId).NotNull().MustExistInDatabase(conceptService);
             RuleFor(x => x.Title).NotNull().Length(3, 50);

--- a/Lern-API/DataTransferObjects/Requests/ExerciseRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ExerciseRequest.cs
@@ -25,7 +25,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class ExerciseRequestValidator : AbstractValidator<ExerciseRequest>
     {
-        public ExerciseRequestValidator(IService<Concept, ConceptRequest> conceptService, IService<Course, CourseRequest> courseService)
+        public ExerciseRequestValidator(IDatabaseService<Concept, ConceptRequest> conceptService, IDatabaseService<Course, CourseRequest> courseService)
         {
             RuleFor(x => x.ConceptId).MustExistInDatabaseIfNotNull(conceptService).NotNull().When(e => e.CourseId == null).WithMessage("ConceptId and CourseId cannot be both null");
             RuleFor(x => x.CourseId).MustExistInDatabaseIfNotNull(courseService).NotNull().When(e => e.ConceptId == null).WithMessage("ConceptId and CourseId cannot be both null");

--- a/Lern-API/DataTransferObjects/Requests/ForgottenPasswordDefinitionRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ForgottenPasswordDefinitionRequest.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+
+namespace Lern_API.DataTransferObjects.Requests
+{
+    public class ForgottenPasswordDefinitionRequest
+    {
+        public string Token { get; set; }
+        public string Password { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class ForgottenPasswordDefinitionRequestValidator : AbstractValidator<ForgottenPasswordDefinitionRequest>
+    {
+        public ForgottenPasswordDefinitionRequestValidator()
+        {
+            RuleFor(x => x.Token).NotNull().NotEmpty();
+            RuleFor(x => x.Password).NotNull().Length(8, 100);
+        }
+    }
+}

--- a/Lern-API/DataTransferObjects/Requests/ForgottenPasswordRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ForgottenPasswordRequest.cs
@@ -3,16 +3,16 @@ using FluentValidation;
 
 namespace Lern_API.DataTransferObjects.Requests
 {
-    public class ForgottenPasswordDefinitionRequest
+    public class ForgottenPasswordRequest
     {
         public string Token { get; set; }
         public string Password { get; set; }
     }
 
     [ExcludeFromCodeCoverage]
-    public class ForgottenPasswordDefinitionRequestValidator : AbstractValidator<ForgottenPasswordDefinitionRequest>
+    public class ForgottenPasswordRequestValidator : AbstractValidator<ForgottenPasswordRequest>
     {
-        public ForgottenPasswordDefinitionRequestValidator()
+        public ForgottenPasswordRequestValidator()
         {
             RuleFor(x => x.Token).NotNull().NotEmpty();
             RuleFor(x => x.Password).NotNull().Length(8, 100);

--- a/Lern-API/DataTransferObjects/Requests/ModuleRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ModuleRequest.cs
@@ -23,7 +23,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class ModuleRequestValidator : AbstractValidator<ModuleRequest>
     {
-        public ModuleRequestValidator(IService<Subject, SubjectRequest> subjectService)
+        public ModuleRequestValidator(IDatabaseService<Subject, SubjectRequest> subjectService)
         {
             RuleFor(x => x.SubjectId).NotEmpty().MustExistInDatabase(subjectService);
             RuleFor(x => x.Title).NotNull().Length(3, 50);

--- a/Lern-API/DataTransferObjects/Requests/QuestionRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/QuestionRequest.cs
@@ -13,7 +13,7 @@ namespace Lern_API.DataTransferObjects.Requests
     {
         [Required]
         public Guid ExerciseId { get; set; }
-        [Required, EnumDataType(typeof(QuestionType))]
+        [Required]
         public QuestionType Type { get; set; }
         [Required, MinLength(3), MaxLength(300)]
         public string Statement { get; set; }
@@ -26,7 +26,7 @@ namespace Lern_API.DataTransferObjects.Requests
     [ExcludeFromCodeCoverage]
     public class QuestionRequestValidator : AbstractValidator<QuestionRequest>
     {
-        public QuestionRequestValidator(IService<Exercise, ExerciseRequest> exerciseService)
+        public QuestionRequestValidator(IDatabaseService<Exercise, ExerciseRequest> exerciseService)
         {
             RuleFor(x => x.ExerciseId).NotNull().MustExistInDatabase(exerciseService);
             RuleFor(x => x.Statement).NotEmpty().Length(3, 300);

--- a/Lern-API/DataTransferObjects/Requests/UserRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/UserRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
-using Lern_API.Models;
 
 namespace Lern_API.DataTransferObjects.Requests
 {

--- a/Lern-API/DataTransferObjects/Requests/UserRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/UserRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
+using Lern_API.Models;
 
 namespace Lern_API.DataTransferObjects.Requests
 {

--- a/Lern-API/Helpers/Context/HttpContextExtensions.cs
+++ b/Lern-API/Helpers/Context/HttpContextExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Lern_API.Helpers.Context
+{
+    public static class HttpContextExtensions
+    {
+        public static string GetBaseUrl(this HttpContext context) => $"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}";
+    }
+}

--- a/Lern-API/Helpers/JWT/JwtExtensions.cs
+++ b/Lern-API/Helpers/JWT/JwtExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using Lern_API.Models;
@@ -30,6 +31,49 @@ namespace Lern_API.Helpers.JWT
 
             var token = tokenHandler.CreateToken(tokenDescriptor);
             return tokenHandler.WriteToken(token);
+        }
+
+        public static string GenerateForgottenPasswordToken(this User user)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.ASCII.GetBytes(SecretKey);
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(new [] { new Claim("Id", user.Id.ToString()) }),
+                Expires = DateTime.UtcNow.AddMinutes(15),
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+
+        public static Guid? GetUserIdFromToken(string token)
+        {
+            try
+            {
+                var tokenHandler = new JwtSecurityTokenHandler();
+                var key = Encoding.ASCII.GetBytes(Configuration.Get<string>("SecretKey"));
+
+                tokenHandler.ValidateToken(token, new TokenValidationParameters
+                {
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(key),
+                    ValidateIssuer = false,
+                    ValidateAudience = false,
+                    ClockSkew = TimeSpan.Zero
+                }, out var validatedToken);
+                
+                var jwtToken = (JwtSecurityToken) validatedToken;
+                var userId = Guid.Parse(jwtToken.Claims.First(x => x.Type == "Id").Value);
+
+                return userId;
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/Lern-API/Helpers/JWT/JwtExtensions.cs
+++ b/Lern-API/Helpers/JWT/JwtExtensions.cs
@@ -54,7 +54,7 @@ namespace Lern_API.Helpers.JWT
             try
             {
                 var tokenHandler = new JwtSecurityTokenHandler();
-                var key = Encoding.ASCII.GetBytes(Configuration.Get<string>("SecretKey"));
+                var key = Encoding.ASCII.GetBytes(SecretKey);
 
                 tokenHandler.ValidateToken(token, new TokenValidationParameters
                 {

--- a/Lern-API/Helpers/Validation/ValidationExtensions.cs
+++ b/Lern-API/Helpers/Validation/ValidationExtensions.cs
@@ -7,13 +7,13 @@ namespace Lern_API.Helpers.Validation
 {
     public static class ValidationExtensions
     {
-        public static IRuleBuilderOptions<T, Guid> MustExistInDatabase<T, TEntity, TEntityRequest>(this IRuleBuilder<T, Guid> rule, IService<TEntity, TEntityRequest> service)
+        public static IRuleBuilderOptions<T, Guid> MustExistInDatabase<T, TEntity, TEntityRequest>(this IRuleBuilder<T, Guid> rule, IDatabaseService<TEntity, TEntityRequest> service)
             where TEntity : class, IModelBase, new()
         {
             return rule.MustAsync(async (_, id, token) => await service.Exists(id, token)).WithMessage($"Provided {typeof(T).Name} does not exist");
         }
 
-        public static IRuleBuilderOptions<T, Guid?> MustExistInDatabaseIfNotNull<T, TEntity, TEntityRequest>(this IRuleBuilder<T, Guid?> rule, IService<TEntity, TEntityRequest> service)
+        public static IRuleBuilderOptions<T, Guid?> MustExistInDatabaseIfNotNull<T, TEntity, TEntityRequest>(this IRuleBuilder<T, Guid?> rule, IDatabaseService<TEntity, TEntityRequest> service)
             where TEntity : class, IModelBase, new()
         {
             return rule.MustAsync(async (_, id, token) =>

--- a/Lern-API/Lern-API.csproj
+++ b/Lern-API/Lern-API.csproj
@@ -24,19 +24,23 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
     <PackageReference Include="CancellationTokenAnalyzers" Version="1.0.1" />
+    <PackageReference Include="FluentEmail.Liquid" Version="3.0.0" />
+    <PackageReference Include="FluentEmail.MailKit" Version="3.0.0" />
     <PackageReference Include="FluentValidation" Version="10.1.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Flurl" Version="3.0.2" />
     <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.5">
+    <PackageReference Include="MailKit" Version="2.11.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Npgsql" Version="5.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.5.1" />
+    <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Lern-API/Lern-API.csproj
+++ b/Lern-API/Lern-API.csproj
@@ -49,6 +49,18 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Templates\examples.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Templates\RecoverAccount.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Templates\_layout.liquid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/Lern-API/Migrations/20210501154218_FixUserManager.Designer.cs
+++ b/Lern-API/Migrations/20210501154218_FixUserManager.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Lern_API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Lern_API.Migrations
 {
     [DbContext(typeof(LernContext))]
-    partial class LernContextModelSnapshot : ModelSnapshot
+    [Migration("20210501154218_FixUserManager")]
+    partial class FixUserManager
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -320,6 +322,7 @@ namespace Lern_API.Migrations
                         .HasColumnType("uuid");
 
                     b.Property<string>("Explanation")
+                        .IsRequired()
                         .HasMaxLength(3000)
                         .HasColumnType("character varying(3000)");
 

--- a/Lern-API/Migrations/20210501154218_FixUserManager.cs
+++ b/Lern-API/Migrations/20210501154218_FixUserManager.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Lern_API.Migrations
+{
+    public partial class FixUserManager : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Users_ManagerId",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ManagerId",
+                table: "Users",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Users_ManagerId",
+                table: "Users",
+                column: "ManagerId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Users_ManagerId",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ManagerId",
+                table: "Users",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Users_ManagerId",
+                table: "Users",
+                column: "ManagerId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Lern-API/Models/User.cs
+++ b/Lern-API/Models/User.cs
@@ -15,7 +15,7 @@ namespace Lern_API.Models
         [ReadOnly(true)]
         public DateTime UpdatedAt { get; set; }
         [ReadOnly(true)]
-        public Guid ManagerId { get; set; }
+        public Guid? ManagerId { get; set; }
         [ReadOnly(true)]
         public User Manager { get; set; }
         [Required, MinLength(3), MaxLength(50)]

--- a/Lern-API/Services/DatabaseService.cs
+++ b/Lern-API/Services/DatabaseService.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Lern_API.Services
 {
-    public interface IService<TEntity, in TDataTransferObject> where TEntity : class, IModelBase, new()
+    public interface IDatabaseService<TEntity, in TDataTransferObject> where TEntity : class, IModelBase, new()
     {
         Task<IEnumerable<TEntity>> GetAll(CancellationToken token = default);
         Task<TEntity> Get(Guid id, CancellationToken token = default);
@@ -20,12 +20,12 @@ namespace Lern_API.Services
         Task<T> ExecuteTransaction<T>(Func<DbSet<TEntity>, T> operations, CancellationToken token = default);
     }
 
-    public class Service<TEntity, TDataTransferObject> : IService<TEntity, TDataTransferObject> where TEntity : class, IModelBase, new()
+    public class DatabaseService<TEntity, TDataTransferObject> : IDatabaseService<TEntity, TDataTransferObject> where TEntity : class, IModelBase, new()
     {
         protected LernContext Context { get; }
         protected DbSet<TEntity> DbSet { get; }
 
-        public Service(LernContext context)
+        public DatabaseService(LernContext context)
         {
             Context = context;
             DbSet = Context.Set<TEntity>();

--- a/Lern-API/Services/MailService.cs
+++ b/Lern-API/Services/MailService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentEmail.Core;
+using FluentEmail.Core.Models;
+using Lern_API.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lern_API.Services
+{
+    public interface IMailService
+    {
+        Task<SendResponse> SendEmailAsync<T>(User recipient, string subject, string template, T model, CancellationToken token = default);
+        Task<SendResponse> SendEmailAsync<T>(string recipientName, string recipientAddress, string subject, string template, T model, CancellationToken token = default);
+    }
+
+    public class MailService : IMailService
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public MailService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public async Task<SendResponse> SendEmailAsync<T>(User recipient, string subject, string template, T model, CancellationToken token = default)
+        {
+            return await SendEmailAsync($"{recipient.Firstname} {recipient.Lastname}", recipient.Email, subject, template, model, token);
+        }
+
+        public async Task<SendResponse> SendEmailAsync<T>(string recipientName, string recipientAddress, string subject, string template, T model, CancellationToken token = default)
+        {
+            using var scope = _serviceProvider.CreateScope();
+
+            return await scope.ServiceProvider.GetRequiredService<IFluentEmailFactory>()
+                .Create()
+                .To(recipientAddress, recipientName)
+                .Subject(subject)
+                .UsingTemplateFromFile(Path.Combine("Templates", $"{template}.liquid"), model)
+                .SendAsync(token);
+        }
+    }
+}

--- a/Lern-API/Services/MailService.cs
+++ b/Lern-API/Services/MailService.cs
@@ -33,6 +33,8 @@ namespace Lern_API.Services
         {
             using var scope = _serviceProvider.CreateScope();
 
+            // This method is untestable because of this line
+            // Unfortunately, this line is required for the IFluentEmailFactory to be retrieved without crashing the entire server
             return await scope.ServiceProvider.GetRequiredService<IFluentEmailFactory>()
                 .Create()
                 .To(recipientAddress, recipientName)

--- a/Lern-API/Services/UserService.cs
+++ b/Lern-API/Services/UserService.cs
@@ -67,7 +67,7 @@ namespace Lern_API.Services
 
             if (user != null)
             {
-                await _mails.SendEmailAsync(user, "Account recovery", "RecoverAccount", new
+                await _mails.SendEmailAsync(user, "Récupération du compte", "RecoverAccount", new
                 {
                     Username = user.Nickname,
                     GeneratedLink = Url.Combine(appBaseUrl, user.GenerateForgottenPasswordToken())
@@ -88,6 +88,9 @@ namespace Lern_API.Services
                 return false;
 
             var user = await Get(userId.Value, token);
+
+            if (user == null)
+                return false;
 
             var userRequest = new UserRequest();
             userRequest.CloneFrom(user);

--- a/Lern-API/Services/UserService.cs
+++ b/Lern-API/Services/UserService.cs
@@ -31,6 +31,7 @@ namespace Lern_API.Services
         public new async Task<User> Create(UserRequest entity, CancellationToken token = default)
         {
             entity.Password = BCrypt.Net.BCrypt.EnhancedHashPassword(entity.Password);
+            entity.Email = entity.Email.ToLowerInvariant();
 
             return await base.Create(entity, token);
         }
@@ -45,12 +46,14 @@ namespace Lern_API.Services
                 entity.Password = storedUser.Password;
             }
 
+            entity.Email = entity.Email.ToLowerInvariant();
+
             return await base.Update(id, entity, token);
         }
 
         public async Task<LoginResponse> Login(LoginRequest request, CancellationToken token = default)
         {
-            var user = await DbSet.FirstOrDefaultAsync(x => x.Nickname == request.Login || x.Email == request.Login, token);
+            var user = await DbSet.FirstOrDefaultAsync(x => x.Nickname == request.Login || x.Email == request.Login.ToLowerInvariant(), token);
 
             if (user == null || !BCrypt.Net.BCrypt.EnhancedVerify(request.Password, user.Password))
                 return null;
@@ -63,7 +66,7 @@ namespace Lern_API.Services
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var user = await DbSet.FirstOrDefaultAsync(x => x.Nickname == login || x.Email == login, token);
+            var user = await DbSet.FirstOrDefaultAsync(x => x.Nickname == login || x.Email == login.ToLowerInvariant(), token);
 
             if (user != null)
             {

--- a/Lern-API/Services/UserService.cs
+++ b/Lern-API/Services/UserService.cs
@@ -76,7 +76,7 @@ namespace Lern_API.Services
             
             if (stopwatch.ElapsedMilliseconds < 2000)
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(2000 - stopwatch.ElapsedMilliseconds), token);
+                await Task.Delay(TimeSpan.FromMilliseconds(2001 - stopwatch.ElapsedMilliseconds), token);
             }
         }
 

--- a/Lern-API/Templates/RecoverAccount.liquid
+++ b/Lern-API/Templates/RecoverAccount.liquid
@@ -1,0 +1,22 @@
+{% layout '_layout' %}
+
+{% section summary %}
+    Vous avez perdu votre mot de passe, {{ Username }} ?
+{% endsection %}
+
+<table class="container paragraph-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" valign="top">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+                <tr>
+                    <td class="paragraph-block__content" style="padding: 25px 0 18px 0; font-size: 16px; line-height: 27px; color: #969696;" align="left">
+                        Vous avez perdu votre mot de passe, <b>{{ Username }}</b> ?<br />
+                        Pas de panique ! Vous pouvez utiliser <a href="{{ GeneratedLink }}">ce lien</a> dans les 15 prochaines minutes pour en choisir un nouveau.<br />
+                        Si cette demande ne provient pas de vous, vous pouvez ignorer ce message sans vous faire de soucis.<br /><br />
+                        <b>A très vite sur Lern. !</b>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>

--- a/Lern-API/Templates/_layout.liquid
+++ b/Lern-API/Templates/_layout.liquid
@@ -1,0 +1,203 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+		<title>Lern.</title>
+		<style type="text/css">
+			/* ----- Custom Font Import ----- */
+			@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin,latin-ext);
+
+			/* ----- Text Styles ----- */
+			table{
+				font-family: 'Lato', Arial, sans-serif;
+				-webkit-font-smoothing: antialiased;
+				-moz-font-smoothing: antialiased;
+				font-smoothing: antialiased;
+			}
+
+			@media only screen and (max-width: 700px){
+				/* ----- Base styles ----- */
+				.full-width-container{
+					padding: 0 !important;
+				}
+
+				.container{
+					width: 100% !important;
+				}
+
+				/* ----- Header ----- */
+				.header td{
+					padding: 30px 15px 30px 15px !important;
+				}
+
+				/* ----- Projects list ----- */
+				.projects-list{
+					display: block !important;
+				}
+
+				.projects-list tr{
+					display: block !important;
+				}
+
+				.projects-list td{
+					display: block !important;
+				}
+
+				.projects-list tbody{
+					display: block !important;
+				}
+
+				.projects-list img{
+					margin: 0 auto 25px auto;
+				}
+
+				/* ----- Half block ----- */
+				.half-block{
+					display: block !important;
+				}
+
+				.half-block tr{
+					display: block !important;
+				}
+
+				.half-block td{
+					display: block !important;
+				}
+
+				.half-block__image{
+					width: 100% !important;
+					background-size: cover;
+				}
+
+				.half-block__content{
+					width: 100% !important;
+					box-sizing: border-box;
+					padding: 25px 15px 25px 15px !important;
+				}
+
+				/* ----- Hero subheader ----- */
+				.hero-subheader__title{
+					padding: 80px 15px 15px 15px !important;
+					font-size: 35px !important;
+				}
+
+				.hero-subheader__content{
+					padding: 0 15px 90px 15px !important;
+				}
+
+				/* ----- Title block ----- */
+				.title-block{
+					padding: 0 15px 0 15px;
+				}
+
+				/* ----- Paragraph block ----- */
+				.paragraph-block__content{
+					padding: 25px 15px 18px 15px !important;
+				}
+
+				/* ----- Info bullets ----- */
+				.info-bullets{
+					display: block !important;
+				}
+
+				.info-bullets tr{
+					display: block !important;
+				}
+
+				.info-bullets td{
+					display: block !important;
+				}
+
+				.info-bullets tbody{
+					display: block;
+				}
+
+				.info-bullets__icon{
+					text-align: center;
+					padding: 0 0 15px 0 !important;
+				}
+
+				.info-bullets__content{
+					text-align: center;
+				}
+
+				.info-bullets__block{
+					padding: 25px !important;
+				}
+
+				/* ----- CTA block ----- */
+				.cta-block__title{
+					padding: 35px 15px 0 15px !important;
+				}
+
+				.cta-block__content{
+					padding: 20px 15px 27px 15px !important;
+				}
+
+				.cta-block__button{
+					padding: 0 15px 0 15px !important;
+				}
+			}
+		</style>
+
+		<!--[if gte mso 9]><xml>
+			<o:OfficeDocumentSettings>
+				<o:AllowPNG/>
+				<o:PixelsPerInch>96</o:PixelsPerInch>
+			</o:OfficeDocumentSettings>
+		</xml><![endif]-->
+	</head>
+
+	<body style="padding: 0; margin: 0;" bgcolor="#eeeeee">
+		<span style="color:transparent !important; overflow:hidden !important; display:none !important; line-height:0px !important; height:0 !important; opacity:0 !important; visibility:hidden !important; width:0 !important; mso-hide:all;">{%- rendersection summary -%}</span>
+
+		<!-- / Full width container -->
+		<table class="full-width-container" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" bgcolor="#eeeeee" style="width: 100%; height: 100%; padding: 30px 0 30px 0;">
+			<tr>
+				<td align="center" valign="top">
+					<!-- / 700px container -->
+					<table class="container" border="0" cellpadding="0" cellspacing="0" width="700" bgcolor="#ffffff" style="width: 700px;">
+						<tr>
+							<td align="center" valign="top">
+								<!-- / Header -->
+								<table class="container header" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+									<tr>
+										<td style="padding: 30px 0 30px 0; border-bottom: solid 1px #eeeeee;" align="left">
+                                            {% comment %} TODO: put the real logo in place and a link to production {% endcomment %}
+											<a href="#" style="font-size: 30px; text-decoration: none; color: #000000;">Lern.</a>
+										</td>
+									</tr>
+								</table>
+								<!-- /// Header -->
+
+                                {% renderbody %}
+
+								<!-- / Footer -->
+								<table class="container" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+									<tr>
+										<td align="center">
+											<table class="container" border="0" cellpadding="0" cellspacing="0" width="620" align="center" style="border-top: 1px solid #eeeeee; width: 620px;">
+												<tr>
+													<td style="text-align: center; padding: 50px 0 10px 0;">
+                                                        {% comment %} TODO: put the real logo in place and a link to production {% endcomment %}
+														<a href="#" style="font-size: 28px; text-decoration: none; color: #d5d5d5;">Lern.</a>
+													</td>
+												</tr>
+
+												<tr>
+													<td style="color: #d5d5d5; text-align: center; font-size: 15px; padding: 10px 0 60px 0; line-height: 22px;">Copyright &copy; 2021 <span style="text-decoration: none; border-bottom: 1px solid #d5d5d5; color: #d5d5d5;">L'équipe Lern.</span> <br />Tous droits réservés.</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<!-- /// Footer -->
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>

--- a/Lern-API/Templates/examples.liquid
+++ b/Lern-API/Templates/examples.liquid
@@ -1,0 +1,315 @@
+{% comment %}                     
+<!-- / Hero subheader -->
+<table class="container hero-subheader" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+    <tr>
+        <td class="hero-subheader__title" style="font-size: 43px; font-weight: bold; padding: 80px 0 15px 0;" align="left">{}</td>
+    </tr>
+
+    <tr>
+        <td class="hero-subheader__content" style="font-size: 16px; line-height: 27px; color: #969696; padding: 0 60px 90px 0;" align="left">Sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo.</td>
+    </tr>
+</table>
+<!-- /// Hero subheader -->
+
+<!-- / Title -->
+<table class="container title-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" valign="top">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+                <tr>
+                    <td style="border-bottom: solid 1px #eeeeee; padding: 35px 0 18px 0; font-size: 26px;" align="left">Recent Works</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Title -->
+
+<!-- / Projects list -->
+<table class="container projects-list" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 25px;">
+    <tr>
+        <td>
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="100%">
+                <tr>
+                    <td align="left">
+                        <a href="#"><img src="img/img1.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+
+                    <td align="left">
+                        <a href="#"><img src="img/img2.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+
+                    <td align="left">
+                        <a href="#"><img src="img/img3.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="left">
+                        <a href="#"><img src="img/img4.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+
+                    <td align="left">
+                        <a href="#"><img src="img/img5.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+
+                    <td align="left">
+                        <a href="#"><img src="img/img6.jpg" width="235" height="235" border="0" style="display: block;"></a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Projects list -->
+
+<!-- / Title -->
+<table class="container title-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" valign="top">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+                <tr>
+                    <td style="border-bottom: solid 1px #eeeeee; padding: 35px 0 18px 0; font-size: 26px;" align="left">Simple text</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Title -->
+
+<!-- / Paragraph -->
+<table class="container paragraph-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" valign="top">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+                <tr>
+                    <td class="paragraph-block__content" style="padding: 25px 0 18px 0; font-size: 16px; line-height: 27px; color: #969696;" align="left">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+                    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Paragraph -->
+
+<!-- / Half block -->
+<table class="container half-block" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 25px;">
+    <tr>
+        <td>
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="100%">
+                <tr>
+                    <td class="half-block__image" style="width: 353px; height: 325px;" width="353" height="325" background="img/img14.jpg">
+                    <!--[if gte mso 9]>
+                    <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width: 353px; height: 325px;" width="353" height="325">
+                    <v:fill type="frame" src="img/img14.jpg" color="#488bd3" />
+                    <v:textbox inset="0,0,0,0">
+                    <![endif]-->
+
+                    <!--[if gte mso 9]>
+                    </v:textbox>
+                    </v:rect>
+                    <![endif]-->
+                    </td>
+
+                    <td class="half-block__content" style="width: 50%; padding: 0 25px 0 25px; font-size: 16px; line-height: 27px; color: #969696; text-align: center;">
+                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Half block -->
+
+<!-- / Half block -->
+<table class="container half-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td>
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="100%">
+                <tr>
+                    <td class="half-block__content" style="width: 50%; padding: 0 25px 0 25px; font-size: 16px; line-height: 27px; color: #969696; text-align: center;">
+                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+                    </td>
+
+                    <td class="half-block__image" style="width: 353px; height: 325px;" width="353" height="325" background="img/img15.jpg">
+                    <!--[if gte mso 9]>
+                    <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width: 353px; height: 325px;" width="353" height="325">
+                    <v:fill type="frame" src="img/img15.jpg" color="#488bd3" />
+                    <v:textbox inset="0,0,0,0">
+                    <![endif]-->
+
+                    <!--[if gte mso 9]>
+                    </v:textbox>
+                    </v:rect>
+                    <![endif]-->
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Half block -->
+
+<!-- / Divider -->
+<table class="container" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 25px;" align="center">
+    <tr>
+        <td align="center">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" align="center" style="border-bottom: solid 1px #eeeeee; width: 620px;">
+                <tr>
+                    <td align="center">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Divider -->
+
+<!-- / CTA Block -->
+<table class="container cta-block" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" valign="top">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" style="width: 620px;">
+                <tr>
+                    <td class="cta-block__title" style="padding: 35px 0 0 0; font-size: 26px; text-align: center;">About Us</td>
+                </tr>
+
+                <tr>
+                    <td class="cta-block__content" style="padding: 20px 0 27px 0; font-size: 16px; line-height: 27px; color: #969696; text-align: center;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat.</td>
+                </tr>
+
+                <tr>
+                    <td align="center">
+                        <table class="container" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="cta-block__button" width="230" align="center" style="width: 200px;">
+                                    <a href="http://slicejack.com/" style="border: 3px solid #eeeeee; color: #969696; text-decoration: none; padding: 15px 45px; text-transform: uppercase; display: block; text-align: center; font-size: 16px;">Visit Us</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// CTA Block -->
+
+<!-- / Divider -->
+<table class="container" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 25px;" align="center">
+    <tr>
+        <td align="center">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" align="center" style="border-bottom: solid 1px #eeeeee; width: 620px;">
+                <tr>
+                    <td align="center">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Divider -->
+
+<!-- / Info Bullets -->
+<table class="container info-bullets" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+    <tr>
+        <td align="center">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" align="center" style="width: 620px;">
+                <tr>
+                    <td class="info-bullets__block" style="padding: 30px 30px 15px 30px;" align="center">
+                        <table class="container" border="0" cellpadding="0" cellspacing="0" align="center">
+                            <tr>
+                                <td class="info-bullets__icon" style="padding: 0 15px 0 0;">
+                                    <img src="img/img13.png">
+                                </td>
+
+                                <td class="info-bullets__content" style="color: #969696; font-size: 16px;">contact@example.com</td>
+                            </tr>
+                        </table>
+                    </td>
+
+                    <td class="info-bullets__block" style="padding: 30px 30px 15px 30px;" align="center">
+                        <table class="container" border="0" cellpadding="0" cellspacing="0" align="center">
+                            <tr>
+                                <td class="info-bullets__icon" style="padding: 0 15px 0 0;">
+                                    <img src="img/img11.png">
+                                </td>
+
+                                <td class="info-bullets__content" style="color: #969696; font-size: 16px;">(541) 754-3010</td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="info-bullets__block" style="padding: 30px;" align="center">
+                        <table class="container" border="0" cellpadding="0" cellspacing="0" align="center">
+                            <tr>
+                                <td class="info-bullets__icon" style="padding: 0 15px 0 0;">
+                                    <img src="img/img12.png">
+                                </td>
+
+                                <td class="info-bullets__content" style="color: #969696; font-size: 16px;">New York, 222 West 23rd</td>
+                            </tr>
+                        </table>
+                    </td>
+
+                    <td class="info-bullets__block" style="padding: 30px;" align="center">
+                        <table class="container" border="0" cellpadding="0" cellspacing="0" align="center">
+                            <tr>
+                                <td class="info-bullets__icon" style="padding: 0 15px 0 0;">
+                                    <img src="img/img12.png">
+                                </td>
+
+                                <td class="info-bullets__content" style="color: #969696; font-size: 16px;">Paris, Champ de Mars 54</td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Info Bullets -->
+
+<!-- / Social nav -->
+<table class="container" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+    <tr>
+        <td align="center">
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="620" align="center" style="border-top: 1px solid #eeeeee; width: 620px;">
+                <tr>
+                    <td align="center" style="padding: 30px 0 30px 0;">
+                        <a href="#">
+                            <img src="img/img7.png" border="0">
+                        </a>
+                    </td>
+
+                    <td align="center" style="padding: 30px 0 30px 0;">
+                        <a href="#">
+                            <img src="img/img8.png" border="0">
+                        </a>
+                    </td>
+
+                    <td align="center" style="padding: 30px 0 30px 0;">
+                        <a href="#">
+                            <img src="img/img9.png" border="0">
+                        </a>
+                    </td>
+
+                    <td align="center" style="padding: 30px 0 30px 0;">
+                        <a href="#">
+                            <img src="img/img10.png" border="0">
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!-- /// Social nav -->
+{% endcomment %}

--- a/Lern-API/appsettings.json
+++ b/Lern-API/appsettings.json
@@ -5,7 +5,15 @@
   "DbUsername": "lern-dev-user",
   "DbPassword": "lern-dev-password",
   "DbDatabase": "lern-dev-db",
-  "DbPort": "5432", 
+  "DbPort": "5432",
+
+  "SmtpServer": "mailhog",
+  "SmtpPort": 1025,
+  "SenderName": "Lern.",
+  "SenderEmail": "lern@lernd.fr",
+  "SmtpUser": "",
+  "SmtpPassword": "",
+  "SmtpUseSsl": false, 
 
   "SecretKey": "7Cyj9sJ9X8vKJwG2k23ix3UE6XRPF2JDuglBxHyWz88Wi36f5ykJdgadDXT8yY2DMikwR6TG3nx5vKI2q8VDjWOZkMRFTEc64X0Qavg62WZWwm1gqC2s8A7MwygQft",
 

--- a/docker-compose.visual-studio.yml
+++ b/docker-compose.visual-studio.yml
@@ -10,6 +10,7 @@ services:
      - database
     networks:
      - postgres
+     - mailhog
   database:
     image: postgres:12-alpine
     environment:
@@ -24,9 +25,22 @@ services:
     networks:
      - postgres
     restart: unless-stopped
+  mailhog:
+    image: mailhog/mailhog
+    environment:
+      MH_STORAGE: maildir
+    ports:
+     - 1025:1025
+     - 8025:8025
+    volumes:
+     - mailhog:/maildir
+    networks:
+     - mailhog
 
 networks:
   postgres:
+  mailhog:
 
 volumes:
   postgres:
+  mailhog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,15 @@ services:
       context: .
       dockerfile: Lern-API/Dockerfile
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=http://+:80
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:80
     ports:
      - 81:80
     depends_on:
      - database
     networks:
      - postgres
+     - mailhog
   database:
     image: postgres:12-alpine
     environment:
@@ -29,9 +30,22 @@ services:
     networks:
      - postgres
     restart: unless-stopped
+  mailhog:
+    image: mailhog/mailhog
+    environment:
+      MH_STORAGE: maildir
+    ports:
+     - 1025:1025
+     - 8025:8025
+    volumes:
+     - mailhog:/maildir
+    networks:
+     - mailhog
 
 networks:
   postgres:
+  mailhog:
 
 volumes:
   postgres:
+  mailhog:


### PR DESCRIPTION
Ajout des routes de récupération de compte :
 - `GET /api/ForgottenPassword?login=xxx` pour provoquer un envoi d'email avec un token de modification de mot de passe
 - `POST /api/ForgottenPassword` pour modifier le mot de passe en utilisant le token récupéré par mail

Pour les besoins de cette PR, un service `mailhog` a été ajouté et est accessible via `localhost:8025`