### PR TITLE
Enregistrement de la progression utilisateur

### DIFF
--- a/Lern-API.Tests/Controllers/ProgressionControllerShould.cs
+++ b/Lern-API.Tests/Controllers/ProgressionControllerShould.cs
@@ -8,7 +8,6 @@ using Lern_API.Controllers;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.DataTransferObjects.Responses;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
@@ -22,11 +21,11 @@ namespace Lern_API.Tests.Controllers
     {
         [Theory]
         [AutoMoqData]
-        public async Task Return_All_Progressions(Mock<IProgressionService> service, IDatabaseService<Subject, SubjectRequest> subjects, List<Progression> progressions, User user)
+        public async Task Return_All_Progressions(Mock<IProgressionService> service, ISubjectService subjects, IConceptService concepts, List<Progression> progressions, User user)
         {
             service.Setup(x => x.GetAll(user, It.IsAny<CancellationToken>())).ReturnsAsync(progressions);
 
-            var controller = TestSetup.SetupController<ProgressionController>(service.Object, subjects).SetupSession(user);
+            var controller = TestSetup.SetupController<ProgressionController>(service.Object, subjects, concepts).SetupSession(user);
 
             var result = await controller.GetProgressions();
             
@@ -35,7 +34,7 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Return_Progression_Or_One_Of_204_404(Mock<IProgressionService> service, Mock<IDatabaseService<Subject, SubjectRequest>> subjects, Progression progression, User user, Subject subject, Subject badSubject)
+        public async Task Return_Progression_Or_One_Of_204_404(Mock<IProgressionService> service, Mock<ISubjectService> subjects, IConceptService concepts, Progression progression, User user, Subject subject, Subject badSubject)
         {
             subjects.Setup(x => x.Get(subject.Id, It.IsAny<CancellationToken>())).ReturnsAsync(subject);
             subjects.Setup(x => x.Get(badSubject.Id, It.IsAny<CancellationToken>())).ReturnsAsync(badSubject);
@@ -44,7 +43,7 @@ namespace Lern_API.Tests.Controllers
             service.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
             service.Setup(x => x.Get(user, badSubject, It.IsAny<CancellationToken>())).ReturnsAsync((Progression) null);
 
-            var controller = TestSetup.SetupController<ProgressionController>(service.Object, subjects.Object).SetupSession(user);
+            var controller = TestSetup.SetupController<ProgressionController>(service.Object, subjects.Object, concepts).SetupSession(user);
 
             var result = await controller.GetProgression(subject.Id);
             var result204 = await controller.GetProgression(badSubject.Id);
@@ -57,6 +56,38 @@ namespace Lern_API.Tests.Controllers
 
             result404.Value.Should().BeNull();
             result404.Result.Should().BeOfType(typeof(NotFoundResult));
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Progression_Or_403(Mock<IProgressionService> service, Mock<ISubjectService> subjects, Mock<IConceptService> concepts, User user, Subject subject, Subject invalidSubject, Concept concept)
+        {
+            concepts.Setup(x => x.Get(concept.Id, It.IsAny<CancellationToken>())).ReturnsAsync(concept);
+            subjects.Setup(x => x.Get(subject.Id, It.IsAny<CancellationToken>())).ReturnsAsync(subject);
+            subjects.Setup(x => x.Get(invalidSubject.Id, It.IsAny<CancellationToken>())).ReturnsAsync(invalidSubject);
+
+            service.Setup(x => x.Update(user, subject, concept, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            service.Setup(x => x.Update(user, invalidSubject, concept, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            var controller = TestSetup.SetupController<ProgressionController>(service.Object, subjects.Object, concepts.Object).SetupSession(user);
+
+            var validRequest = new ProgressionRequest
+            {
+                ConceptId = concept.Id,
+                SubjectId = subject.Id,
+            };
+
+            var invalidRequest = new ProgressionRequest
+            {
+                ConceptId = concept.Id,
+                SubjectId = invalidSubject.Id,
+            };
+
+            var result = await controller.UpdateProgression(validRequest);
+            var result403 = await controller.UpdateProgression(invalidRequest);
+
+            result.Should().NotBeNull().And.BeOfType<OkResult>();
+            result403.Should().NotBeNull().And.BeOfType<ForbidResult>();
         }
     }
 }

--- a/Lern-API.Tests/Controllers/SubjectsControllerShould.cs
+++ b/Lern-API.Tests/Controllers/SubjectsControllerShould.cs
@@ -23,7 +23,7 @@ namespace Lern_API.Tests.Controllers
         [AutoMoqData]
         public async Task Return_All_Subjects(Mock<ISubjectService> service, IAuthorizationService authorization, List<Subject> subjects)
         {
-            service.Setup(x => x.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync(subjects);
+            service.Setup(x => x.GetAvailable(It.IsAny<CancellationToken>())).ReturnsAsync(subjects);
 
             var controller = TestSetup.SetupController<SubjectsController>(service.Object, authorization);
 

--- a/Lern-API.Tests/Services/ProgressionServiceShould.cs
+++ b/Lern-API.Tests/Services/ProgressionServiceShould.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
@@ -91,7 +90,7 @@ namespace Lern_API.Tests.Services
 
             var storedResult = context.Progressions.FirstOrDefault();
 
-            result.Should().NotBeNull().And.BeEquivalentTo(progression, TestSetup.IgnoreTimestamps<Progression>());
+            result.Should().BeTrue();
             storedResult.Should().NotBeNull().And.BeEquivalentTo(progression, TestSetup.IgnoreTimestamps<Progression>());
         }
 
@@ -132,7 +131,7 @@ namespace Lern_API.Tests.Services
 
             var storedResult = context.Progressions.FirstOrDefault();
 
-            result.Should().NotBeNull().And.BeEquivalentTo(expected, TestSetup.IgnoreTimestamps<Progression>());
+            result.Should().BeTrue();
             storedResult.Should().NotBeNull().And.BeEquivalentTo(expected, TestSetup.IgnoreTimestamps<Progression>());
         }
 

--- a/Lern-API.Tests/Services/SubjectServiceShould.cs
+++ b/Lern-API.Tests/Services/SubjectServiceShould.cs
@@ -75,7 +75,7 @@ namespace Lern_API.Tests.Services
             await context.SaveChangesAsync();
 
             var service = new SubjectService(context, TestSetup.SetupHttpContext(), authorizationService, progressionService);
-            var result = await service.GetAll();
+            var result = await service.GetAvailable();
 
             result.Should().BeEquivalentTo(subjects).And.NotBeEquivalentTo(invalidSubjects);
         }

--- a/Lern-API/Controllers/ProgressionController.cs
+++ b/Lern-API/Controllers/ProgressionController.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.DataTransferObjects.Responses;
 using Lern_API.Helpers.JWT;
-using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 using Microsoft.AspNetCore.Mvc;
 
@@ -17,12 +15,14 @@ namespace Lern_API.Controllers
     public class ProgressionController : ControllerBase
     {
         private readonly IProgressionService _progression;
-        private readonly IDatabaseService<Subject, SubjectRequest> _subjects;
+        private readonly ISubjectService _subjects;
+        private readonly IConceptService _concepts;
 
-        public ProgressionController(IProgressionService progression, IDatabaseService<Subject, SubjectRequest> subjects)
+        public ProgressionController(IProgressionService progression, ISubjectService subjects, IConceptService concepts)
         {
             _progression = progression;
             _subjects = subjects;
+            _concepts = concepts;
         }
 
         /// <summary>
@@ -61,6 +61,24 @@ namespace Lern_API.Controllers
                 return NoContent();
 
             return new ProgressionResponse(progression);
+        }
+
+        /// <summary>
+        /// Updates the current user's progression in the provided subject
+        /// </summary>
+        /// <param name="request">The subject to update to the provided concept</param>
+        /// <response code="200">If the progression has successfully been updated</response>
+        /// <response code="403">If the current user cannot update its progression in the provided subject (see simultaneous subjects restrictions)</response>
+        [RequireAuthentication]
+        [HttpPut]
+        public async Task<IActionResult> UpdateProgression(ProgressionRequest request)
+        {
+            var subject = await _subjects.Get(request.SubjectId, HttpContext.RequestAborted);
+            var concept = await _concepts.Get(request.ConceptId, HttpContext.RequestAborted);
+            
+            var result = await _progression.Update(HttpContext.GetUser(), subject, concept, HttpContext.RequestAborted);
+
+            return result ? Ok() : Forbid();
         }
     }
 }

--- a/Lern-API/Controllers/SubjectsController.cs
+++ b/Lern-API/Controllers/SubjectsController.cs
@@ -35,8 +35,8 @@ namespace Lern_API.Controllers
         {
             return new(
                 await _subjects.GetMine(HttpContext.RequestAborted),
-                new List<Subject>(),
-                await _subjects.GetAll(HttpContext.RequestAborted)
+                await _subjects.GetActives(HttpContext.RequestAborted),
+                await _subjects.GetAvailable(HttpContext.RequestAborted)
             );
         }
 

--- a/Lern-API/DataTransferObjects/Requests/ModuleRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ModuleRequest.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using Lern_API.Helpers.Validation;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 
 namespace Lern_API.DataTransferObjects.Requests

--- a/Lern-API/DataTransferObjects/Requests/ProgressionRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ProgressionRequest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+using Lern_API.Helpers.Validation;
+using Lern_API.Services.Database;
+
+namespace Lern_API.DataTransferObjects.Requests
+{
+    public class ProgressionRequest
+    {
+        [Required]
+        public Guid SubjectId { get; set; }
+        [Required]
+        public Guid ConceptId { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class ProgressionRequestValidator : AbstractValidator<ProgressionRequest>
+    {
+        public ProgressionRequestValidator(ISubjectService subjectService, IConceptService conceptService)
+        {
+            RuleFor(x => x.SubjectId).NotEmpty().MustExistInDatabase(subjectService);
+            RuleFor(x => x.ConceptId).NotEmpty().MustExistInDatabase(conceptService);
+        }
+    }
+}

--- a/Lern-API/DataTransferObjects/Responses/ProgressionResponse.cs
+++ b/Lern-API/DataTransferObjects/Responses/ProgressionResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using Lern_API.Helpers.Models;
 using Lern_API.Models;
 
@@ -12,6 +13,9 @@ namespace Lern_API.DataTransferObjects.Responses
         public Subject Subject { get; set; }
         public Concept Concept { get; set; }
         public bool Suspended { get; set; }
+        public bool Completed { get; set; }
+        [Range(0, 100)]
+        public double Completion { get; set; }
 
         public ProgressionResponse(Progression progression)
         {

--- a/Lern-API/Lern-API.csproj
+++ b/Lern-API/Lern-API.csproj
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Npgsql" Version="5.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />

--- a/Lern-API/Migrations/20210615083637_ProgressionCompletion.Designer.cs
+++ b/Lern-API/Migrations/20210615083637_ProgressionCompletion.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Lern_API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Lern_API.Migrations
 {
     [DbContext(typeof(LernContext))]
-    partial class LernContextModelSnapshot : ModelSnapshot
+    [Migration("20210615083637_ProgressionCompletion")]
+    partial class ProgressionCompletion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Lern-API/Migrations/20210615083637_ProgressionCompletion.cs
+++ b/Lern-API/Migrations/20210615083637_ProgressionCompletion.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Lern_API.Migrations
+{
+    public partial class ProgressionCompletion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Completed",
+                table: "Progressions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Completion",
+                table: "Progressions",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Completed",
+                table: "Progressions");
+
+            migrationBuilder.DropColumn(
+                name: "Completion",
+                table: "Progressions");
+        }
+    }
+}

--- a/Lern-API/Models/Progression.cs
+++ b/Lern-API/Models/Progression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Lern_API.Models
 {
@@ -23,5 +24,9 @@ namespace Lern_API.Models
         public Concept Concept { get; set; }
         [ReadOnly(true)]
         public bool Suspended { get; set; }
+        [ReadOnly(true)]
+        public bool Completed { get; set; }
+        [ReadOnly(true), Range(0, 100)]
+        public double Completion { get; set; }
     }
 }

--- a/Lern-API/Services/Database/SubjectService.cs
+++ b/Lern-API/Services/Database/SubjectService.cs
@@ -14,17 +14,49 @@ namespace Lern_API.Services.Database
     public interface ISubjectService : IDatabaseService<Subject, SubjectRequest>
     {
         Task<IEnumerable<Subject>> GetMine(CancellationToken token = default);
-        IQueryable<Subject> GetAvailable();
+        Task<IEnumerable<Subject>> GetAvailable(CancellationToken token = default);
+        Task<IEnumerable<Subject>> GetActives(CancellationToken token = default);
         Task<Subject> UpdateState(Guid id, CancellationToken token = default);
     }
 
     public class SubjectService : DatabaseService<Subject, SubjectRequest>, ISubjectService
     {
         private readonly IAuthorizationService _authorizationService;
+        private readonly IProgressionService _progressionService;
 
-        public SubjectService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService) : base(context, httpContextAccessor)
+        private IQueryable<Subject> AvailableSubjects => DbSet
+            .Include(subject => subject.Author)
+            .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
+            .ThenInclude(module => module.Concepts.Where(concept =>
+                concept.Courses.Any() && concept.Exercises.Any(exercise =>
+                    exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
+            .ThenInclude(concept => concept.Courses)
+            .ThenInclude(course => course.Exercises.Where(exercise =>
+                exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid))))
+            .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
+            .ThenInclude(question => question.Answers)
+            .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
+            .ThenInclude(module => module.Concepts.Where(concept =>
+                concept.Courses.Any() && concept.Exercises.Any(exercise =>
+                    exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
+            .ThenInclude(concept => concept.Exercises.Where(exercise => exercise.Questions.Any()))
+            .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
+            .ThenInclude(question => question.Answers)
+            .Where(subject =>
+                subject.Modules.Any() && subject.Modules.All(module =>
+                    module.Concepts.Any() && module.Concepts.All(concept => concept.Courses.Any() &&
+                                                                            concept.Exercises.Any() &&
+                                                                            concept.Exercises.All(exercise =>
+                                                                                exercise.Questions.Any() &&
+                                                                                exercise.Questions.All(question =>
+                                                                                    question.Answers.Any(answer =>
+                                                                                        answer.Valid))
+                                                                            ))));
+
+        public SubjectService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IProgressionService progressionService) : base(context, httpContextAccessor)
         {
             _authorizationService = authorizationService;
+            _progressionService = progressionService;
         }
 
         protected override IQueryable<Subject> WithDefaultIncludes(DbSet<Subject> set)
@@ -56,7 +88,7 @@ namespace Lern_API.Services.Database
             if (canEdit)
                 return entity;
 
-            return await GetAvailable().FirstOrDefaultAsync(subject => subject.Id == id, token);
+            return await AvailableSubjects.FirstOrDefaultAsync(subject => subject.Id == id, token);
         }
 
         public override async Task<Subject> Create(SubjectRequest entity, CancellationToken token = default)
@@ -79,11 +111,6 @@ namespace Lern_API.Services.Database
             return await UpdateState(result.Id, token);
         }
 
-        public override async Task<IEnumerable<Subject>> GetAll(CancellationToken token = default)
-        {
-            return await GetAvailable().ToListAsync(token);
-        }
-
         public async Task<IEnumerable<Subject>> GetMine(CancellationToken token = default)
         {
             var currentUser = HttpContextAccessor.HttpContext.GetUser();
@@ -91,27 +118,16 @@ namespace Lern_API.Services.Database
             return await WithDefaultIncludes(DbSet).Where(x => x.AuthorId == currentUser.Id).ToListAsync(token);
         }
 
-        public IQueryable<Subject> GetAvailable()
+        public async Task<IEnumerable<Subject>> GetAvailable(CancellationToken token = default)
         {
-            return DbSet
-                .Include(subject => subject.Author)
-                .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
-                .ThenInclude(module => module.Concepts.Where(concept => concept.Courses.Any() && concept.Exercises.Any(exercise => exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
-                .ThenInclude(concept => concept.Courses)
-                .ThenInclude(course => course.Exercises.Where(exercise => exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid))))
-                .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
-                .ThenInclude(question => question.Answers)
-                .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
-                .ThenInclude(module => module.Concepts.Where(concept => concept.Courses.Any() && concept.Exercises.Any(exercise => exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
-                .ThenInclude(concept => concept.Exercises.Where(exercise => exercise.Questions.Any()))
-                .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
-                .ThenInclude(question => question.Answers)
-                .Where(subject =>
-                    subject.Modules.Any() && subject.Modules.All(module =>
-                        module.Concepts.Any() && module.Concepts.All(concept => concept.Courses.Any() && concept.Exercises.Any() && concept.Exercises.All(exercise =>
-                            exercise.Questions.Any() && exercise.Questions.All(question => question.Answers.Any(answer => answer.Valid))
-                    ))
-                ));
+            return await AvailableSubjects.ToListAsync(token);
+        }
+
+        public async Task<IEnumerable<Subject>> GetActives(CancellationToken token = default)
+        {
+            var progressions = await _progressionService.GetAll(HttpContextAccessor.HttpContext.GetUser(), token);
+
+            return progressions.Where(progression => !progression.Suspended).Select(progression => progression.Subject);
         }
         
         public async Task<Subject> UpdateState(Guid id, CancellationToken token = default)
@@ -123,7 +139,7 @@ namespace Lern_API.Services.Database
 
             return await SafeExecute(_ =>
             {
-                subject.State = GetAvailable().Any(x => x.Id == id)
+                subject.State = AvailableSubjects.Any(x => x.Id == id)
                         ? SubjectState.Approved
                         : SubjectState.Invalid;
 


### PR DESCRIPTION
Ajout des champs `Completed` (bool) et `Completion` (double, pourcentage ramené entre 0 et 100) au modèle `Progression` pour suivre la progression utilisateur

Ajout de la route `PUT /api/Progression` pour créer/mettre à jour la progression de l'utilisateur courant sur un sujet donné

La progression de l'utilisateur courant peut être récupérée via `GET /api/Progression`, `GET /api/Progression/{subjectId}` ou encore `GET /api/Subjects` dans le champ `active`