### PR TITLE
Enregistrement des réponses aux questions d'un exercice

### DIFF
--- a/Lern-API.Tests/Controllers/ResultsControllerShould.cs
+++ b/Lern-API.Tests/Controllers/ResultsControllerShould.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Lern_API.Controllers;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Models;
+using Lern_API.Services.Database;
+using Lern_API.Tests.Attributes;
+using Lern_API.Tests.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Lern_API.Tests.Controllers
+{
+    public class ResultsControllerShould
+    {
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_Result_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question, Result entity)
+        {
+            resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+            questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync(question);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+
+            var result = await controller.GetFromQuestion(question.Id);
+
+            result.Should().NotBeNull();
+            result.Value.Should().NotBeNull().And.BeEquivalentTo(entity);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_204_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question)
+        {
+            resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync((Result) null);
+            questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync(question);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+
+            var result = await controller.GetFromQuestion(question.Id);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NoContentResult>();
+            result.Value.Should().BeNull();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_404_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question, Result entity)
+        {
+            resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+            questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync((Question) null);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+
+            var result = await controller.GetFromQuestion(question.Id);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NotFoundResult>();
+            result.Value.Should().BeNull();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_Results_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise, List<Result> entities)
+        {
+            resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(entities);
+            exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync(exercise);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+
+            var result = await controller.GetFromExercise(exercise.Id);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<OkObjectResult>();
+            ((OkObjectResult) result.Result).Value.Should().NotBeNull().And.BeEquivalentTo(entities);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_204_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise)
+        {
+            resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(new List<Result>());
+            exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync(exercise);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+
+            var result = await controller.GetFromExercise(exercise.Id);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NoContentResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_404_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise, List<Result> entities)
+        {
+            resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(entities);
+            exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync((Exercise) null);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+
+            var result = await controller.GetFromExercise(exercise.Id);
+
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Register_Answers(Mock<IResultService> resultService, IQuestionService questionService, IExerciseService exerciseService, User user, List<ResultRequest> entities)
+        {
+            resultService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService).SetupSession(user);
+
+            var result = await controller.RegisterAnswers(entities);
+
+            resultService.VerifyAll();
+            result.Should().NotBeNull();
+            result.Should().BeOfType<OkResult>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Not_Register_Answers_And_403(Mock<IResultService> resultService, IQuestionService questionService, IExerciseService exerciseService, User user, List<ResultRequest> entities)
+        {
+            resultService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService).SetupSession(user);
+
+            var result = await controller.RegisterAnswers(entities);
+
+            resultService.VerifyAll();
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ForbidResult>();
+        }
+    }
+}

--- a/Lern-API.Tests/Services/ResultServiceShould.cs
+++ b/Lern-API.Tests/Services/ResultServiceShould.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Models;
+using Lern_API.Services.Database;
+using Lern_API.Tests.Attributes;
+using Lern_API.Tests.Utils;
+using Xunit;
+
+namespace Lern_API.Tests.Services
+{
+    public class ResultServiceShould
+    {
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_All_From_Subject(User user, Subject subject, List<Result> otherResults, List<Result> randomResults)
+        {
+            var questions = subject.Modules.First().Concepts.First().Exercises.First().Questions;
+            questions.AddRange(subject.Modules.Last().Concepts.Last().Exercises.Last().Questions);
+
+            var entities = questions.Select(question => new Result
+            {
+                QuestionId = question.Id,
+                AnswerId = question.Answers.First().Id,
+                UserId = user.Id
+            }).ToList();
+
+            otherResults.ForEach(x => x.UserId = user.Id);
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(entities);
+            await context.Results.AddRangeAsync(otherResults);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.SaveChangesAsync();
+
+            var service = new ResultService(context);
+
+            var result = await service.GetAll(user, subject);
+
+            result.Should().NotBeNullOrEmpty().And.BeEquivalentTo(entities);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_All_From_Exercise(User user, Exercise exercise, List<Result> otherResults, List<Result> randomResults)
+        {
+            var questions = exercise.Questions;
+
+            var entities = questions.Select(question => new Result
+            {
+                QuestionId = question.Id,
+                AnswerId = question.Answers.First().Id,
+                UserId = user.Id
+            }).ToList();
+
+            otherResults.ForEach(x => x.UserId = user.Id);
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.Exercises.AddAsync(exercise);
+            await context.Results.AddRangeAsync(entities);
+            await context.Results.AddRangeAsync(otherResults);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.SaveChangesAsync();
+
+            var service = new ResultService(context);
+
+            var result = await service.GetAll(user, exercise);
+
+            result.Should().NotBeNullOrEmpty().And.BeEquivalentTo(entities);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Get_From_Question(User user, Question question, List<Result> otherResults, List<Result> randomResults)
+        {
+            var entity = new Result
+            {
+                QuestionId = question.Id,
+                AnswerId = question.Answers.First().Id,
+                UserId = user.Id,
+            };
+
+            otherResults.ForEach(x => x.UserId = user.Id);
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.Questions.AddAsync(question);
+            await context.Results.AddRangeAsync(entity);
+            await context.Results.AddRangeAsync(otherResults);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.SaveChangesAsync();
+
+            var service = new ResultService(context);
+
+            var result = await service.Get(user, question);
+
+            result.Should().NotBeNull().And.BeEquivalentTo(entity);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        public async Task Register_Answers(User user, List<Question> questions)
+        {
+            var answers = questions.Select(question => new ResultRequest
+            {
+                QuestionId = question.Id,
+                AnswerId = question.Answers.First().Id
+            }).ToList();
+
+            var context = TestSetup.SetupContext();
+
+            await context.Users.AddAsync(user);
+            await context.Questions.AddRangeAsync(questions);
+            await context.SaveChangesAsync();
+
+            var service = new ResultService(context);
+
+            var result = await service.RegisterAnswers(user, answers);
+
+            result.Should().BeTrue();
+            context.Results.AsEnumerable().Should().HaveCount(answers.Count);
+        }
+    }
+}

--- a/Lern-API/Controllers/ResultsController.cs
+++ b/Lern-API/Controllers/ResultsController.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Helpers.JWT;
+using Lern_API.Models;
+using Lern_API.Services.Database;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Lern_API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ResultsController : ControllerBase
+    {
+        private readonly IResultService _results;
+        private readonly IQuestionService _questions;
+        private readonly IExerciseService _exercises;
+
+        public ResultsController(IResultService results, IQuestionService questions, IExerciseService exercises)
+        {
+            _results = results;
+            _questions = questions;
+            _exercises = exercises;
+        }
+        
+        /// <summary>
+        /// Returns a single result associated to the provided question and the current user
+        /// </summary>
+        /// <param name="questionId">The ID associated to the question</param>
+        /// <returns>Result associated to the provided question and the current user</returns>
+        /// <response code="200">Result associated to the provided question and the current user</response>
+        /// <response code="204">If the current user has not completed the given question yet</response>
+        /// <response code="404">If the provided question ID does not exist</response>
+        [RequireAuthentication]
+        [HttpGet("question/{questionId:guid}")]
+        public async Task<ActionResult<Result>> GetFromQuestion(Guid questionId)
+        {
+            var question = await _questions.Get(questionId, HttpContext.RequestAborted);
+
+            if (question == null)
+                return NotFound();
+
+            var result = await _results.Get(HttpContext.GetUser(), question, HttpContext.RequestAborted);
+
+            if (result == null)
+                return NoContent();
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a list of results associated to the provided exercise and the current user
+        /// </summary>
+        /// <param name="exerciseId">The ID associated to the exercise</param>
+        /// <returns>Results associated to the provided exercise and the current user</returns>
+        /// <response code="200">Results associated to the provided exercise and the current user</response>
+        /// <response code="204">If the current user has not completed any of the questions inside the provided exercise yet</response>
+        /// <response code="404">If the provided exercise ID does not exist</response>
+        [RequireAuthentication]
+        [HttpGet("exercise/{exerciseId:guid}")]
+        public async Task<ActionResult<IEnumerable<Result>>> GetFromExercise(Guid exerciseId)
+        {
+            var exercise = await _exercises.Get(exerciseId, HttpContext.RequestAborted);
+
+            if (exercise == null)
+                return NotFound();
+
+            var result = await _results.GetAll(HttpContext.GetUser(), exercise, HttpContext.RequestAborted);
+
+            if (result == null || !result.Any())
+                return NoContent();
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Register the provided answers as the current user
+        /// </summary>
+        /// <param name="answers">The answers to register, each associated to the question linked to the answer</param>
+        /// <response code="200">If the provided answers has successfully been registered</response>
+        /// <response code="403">If the current user cannot update its progression in the subject linked to any of the answers (see simultaneous subjects restrictions)</response>
+        [RequireAuthentication]
+        [HttpPost]
+        public async Task<IActionResult> RegisterAnswers(IEnumerable<ResultRequest> answers)
+        {
+            var result = await _results.RegisterAnswers(HttpContext.GetUser(), answers, HttpContext.RequestAborted);
+
+            return result ? Ok() : Forbid();
+        }
+    }
+}

--- a/Lern-API/DataTransferObjects/Requests/QuestionRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/QuestionRequest.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using Lern_API.Helpers.Validation;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 
 namespace Lern_API.DataTransferObjects.Requests

--- a/Lern-API/DataTransferObjects/Requests/ResultRequest.cs
+++ b/Lern-API/DataTransferObjects/Requests/ResultRequest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+using Lern_API.Helpers.Validation;
+using Lern_API.Models;
+using Lern_API.Services.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lern_API.DataTransferObjects.Requests
+{
+    public class ResultRequest
+    {
+        [Required]
+        public Guid QuestionId { get; set; }
+        [Required]
+        public Guid AnswerId { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class ResultRequestValidator : AbstractValidator<ResultRequest>
+    {
+        public ResultRequestValidator(IQuestionService questionService, IDatabaseService<Answer, AnswerRequest> answerService)
+        {
+            RuleFor(x => x.QuestionId).NotNull().MustExistInDatabase(questionService);
+            RuleFor(x => x.AnswerId).NotNull().MustExistInDatabase(answerService)
+                .MustAsync(async (request, answerId, token) => await answerService.ExecuteQuery(async set => await set.AnyAsync(answer => answer.Id == answerId && answer.QuestionId == request.QuestionId, token), token))
+                .WithMessage("Provided Answer does not belong to provided Question");
+        }
+    }
+}

--- a/Lern-API/Helpers/Validation/ValidationExtensions.cs
+++ b/Lern-API/Helpers/Validation/ValidationExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentValidation;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 
 namespace Lern_API.Helpers.Validation

--- a/Lern-API/Models/Answer.cs
+++ b/Lern-API/Models/Answer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Lern_API.Models
 {

--- a/Lern-API/Services/Database/ResultService.cs
+++ b/Lern-API/Services/Database/ResultService.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lern_API.Services.Database
+{
+    public interface IResultService : IAbstractDatabaseService<Result>
+    {
+        Task<IEnumerable<Result>> GetAll(User user, Subject subject, CancellationToken token = default);
+        Task<IEnumerable<Result>> GetAll(User user, Exercise exercise, CancellationToken token = default);
+        Task<Result> Get(User user, Question question, CancellationToken token = default);
+        Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default);
+    }
+
+    public class ResultService : AbstractDatabaseService<Result>, IResultService
+    {
+        public ResultService(LernContext context) : base(context)
+        {
+        }
+
+        protected override IQueryable<Result> WithDefaultIncludes(DbSet<Result> set)
+        {
+            return base.WithDefaultIncludes(set)
+                .Include(result => result.Answer)   
+                .Include(result => result.User);
+        }
+        
+        public async Task<IEnumerable<Result>> GetAll(User user, Subject subject, CancellationToken token = default)
+        {
+            var results = await WithDefaultIncludes(DbSet).Where(x => x.UserId == user.Id).ToListAsync(token);
+
+            return results.Where(x => subject.Modules.Any(module =>
+                module.Concepts.Any(concept =>
+                   concept.Exercises.Any(exercise =>
+                       exercise.Questions.Any(question => question.Id == x.QuestionId)) ||
+                   concept.Courses.Any(course =>
+                       course.Exercises.Any(exercise =>
+                           exercise.Questions.Any(question => question.Id == x.QuestionId)
+                )))));
+        }
+
+        public async Task<IEnumerable<Result>> GetAll(User user, Exercise exercise, CancellationToken token = default)
+        {
+            var results = await WithDefaultIncludes(DbSet).Where(x => x.UserId == user.Id).ToListAsync(token);
+
+            return results.Where(x => exercise.Questions.Any(question => question.Id == x.QuestionId));
+        }
+
+        public async Task<Result> Get(User user, Question question, CancellationToken token = default)
+        {
+            return await WithDefaultIncludes(DbSet).FirstOrDefaultAsync(x => x.UserId == user.Id && x.QuestionId == question.Id, token);
+        }
+
+        public async Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default)
+        {
+            var results = answers.Select(answer => new Result
+            {
+                AnswerId = answer.AnswerId,
+                QuestionId = answer.QuestionId,
+                UserId = user.Id
+            }).ToList();
+
+            return await SafeExecute(async set => await set.AddRangeAsync(results, token), token);
+        }
+    }
+}

--- a/Lern-API/Startup.cs
+++ b/Lern-API/Startup.cs
@@ -135,6 +135,7 @@ namespace Lern_API
             services.AddScoped<ISubjectService, SubjectService>();
             services.AddScoped<ICourseService, CourseService>();
             services.AddScoped<IQuestionService, QuestionService>();
+            services.AddScoped<IResultService, ResultService>();
             services.AddScoped<IProgressionService, ProgressionService>();
             services.AddScoped<IAuthorizationService, AuthorizationService>();
         }


### PR DESCRIPTION
Ajout des routes `/Results` pour la gestion des réponses aux questions des différents exercices