### PR TITLE
 Calcul automatique de la progression utilisateur dans un sujet et ses exercices

### DIFF
--- a/Lern-API.Tests/Controllers/ResultsControllerShould.cs
+++ b/Lern-API.Tests/Controllers/ResultsControllerShould.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Lern_API.Controllers;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.Models;
+using Lern_API.Services;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
@@ -18,12 +19,12 @@ namespace Lern_API.Tests.Controllers
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_Result_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question, Result entity)
+        public async Task Get_Result_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, IStateService stateService, User user, Question question, Result entity)
         {
             resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
             questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync(question);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService, stateService).SetupSession(user);
 
             var result = await controller.GetFromQuestion(question.Id);
 
@@ -33,12 +34,12 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_204_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question)
+        public async Task Get_204_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, IStateService stateService, User user, Question question)
         {
             resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync((Result) null);
             questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync(question);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService, stateService).SetupSession(user);
 
             var result = await controller.GetFromQuestion(question.Id);
 
@@ -49,12 +50,12 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_404_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, User user, Question question, Result entity)
+        public async Task Get_404_From_Question(Mock<IResultService> resultService, Mock<IQuestionService> questionService, IExerciseService exerciseService, IStateService stateService, User user, Question question, Result entity)
         {
             resultService.Setup(x => x.Get(user, question, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
             questionService.Setup(x => x.Get(question.Id, It.IsAny<CancellationToken>())).ReturnsAsync((Question) null);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService.Object, exerciseService, stateService).SetupSession(user);
 
             var result = await controller.GetFromQuestion(question.Id);
 
@@ -65,12 +66,12 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Results_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise, List<Result> entities)
+        public async Task Get_Results_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, IStateService stateService, User user, Exercise exercise, List<Result> entities)
         {
             resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(entities);
             exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync(exercise);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object, stateService).SetupSession(user);
 
             var result = await controller.GetFromExercise(exercise.Id);
 
@@ -81,12 +82,12 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_204_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise)
+        public async Task Get_204_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, IStateService stateService, User user, Exercise exercise)
         {
             resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(new List<Result>());
             exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync(exercise);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object, stateService).SetupSession(user);
 
             var result = await controller.GetFromExercise(exercise.Id);
 
@@ -96,12 +97,12 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_404_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, User user, Exercise exercise, List<Result> entities)
+        public async Task Get_404_From_Exercise(Mock<IResultService> resultService, IQuestionService questionService, Mock<IExerciseService> exerciseService, IStateService stateService, User user, Exercise exercise, List<Result> entities)
         {
             resultService.Setup(x => x.GetAll(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(entities);
             exerciseService.Setup(x => x.Get(exercise.Id, It.IsAny<CancellationToken>())).ReturnsAsync((Exercise) null);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService.Object, stateService).SetupSession(user);
 
             var result = await controller.GetFromExercise(exercise.Id);
 
@@ -111,30 +112,30 @@ namespace Lern_API.Tests.Controllers
 
         [Theory]
         [AutoMoqData]
-        public async Task Register_Answers(Mock<IResultService> resultService, IQuestionService questionService, IExerciseService exerciseService, User user, List<ResultRequest> entities)
+        public async Task Register_Answers(IResultService resultService, IQuestionService questionService, IExerciseService exerciseService, Mock<IStateService> stateService, User user, List<ResultRequest> entities)
         {
-            resultService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            stateService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService, questionService, exerciseService, stateService.Object).SetupSession(user);
 
             var result = await controller.RegisterAnswers(entities);
 
-            resultService.VerifyAll();
+            stateService.VerifyAll();
             result.Should().NotBeNull();
             result.Should().BeOfType<OkResult>();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Not_Register_Answers_And_403(Mock<IResultService> resultService, IQuestionService questionService, IExerciseService exerciseService, User user, List<ResultRequest> entities)
+        public async Task Not_Register_Answers_And_403(Mock<IResultService> resultService, IQuestionService questionService, IExerciseService exerciseService, Mock<IStateService> stateService, User user, List<ResultRequest> entities)
         {
-            resultService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            stateService.Setup(x => x.RegisterAnswers(user, entities, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService).SetupSession(user);
+            var controller = TestSetup.SetupController<ResultsController>(resultService.Object, questionService, exerciseService, stateService.Object).SetupSession(user);
 
             var result = await controller.RegisterAnswers(entities);
 
-            resultService.VerifyAll();
+            stateService.VerifyAll();
             result.Should().NotBeNull();
             result.Should().BeOfType<ForbidResult>();
         }

--- a/Lern-API.Tests/Services/ConceptServiceShould.cs
+++ b/Lern-API.Tests/Services/ConceptServiceShould.cs
@@ -18,7 +18,7 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_Entire_Concept_With_Write_Access(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Concept concept, User user)
+        public async Task Get_Entire_Concept_With_Write_Access(Mock<IAuthorizationService> authorizationService, IStateService stateService, Concept concept, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, concept, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
@@ -31,7 +31,7 @@ namespace Lern_API.Tests.Services
             await context.Concepts.AddRangeAsync(concept);
             await context.SaveChangesAsync();
 
-            var service = new ConceptService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ConceptService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(concept.Id);
 
             result.Should().BeEquivalentTo(concept);
@@ -39,7 +39,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Concept_With_A_Course_And_An_Exercise(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Concept concept, Concept invalidConcept, User user)
+        public async Task Get_Concept_With_A_Course_And_An_Exercise(Mock<IAuthorizationService> authorizationService, IStateService stateService, Concept concept, Concept invalidConcept, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, It.IsAny<Concept>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -55,7 +55,7 @@ namespace Lern_API.Tests.Services
             await context.Concepts.AddAsync(invalidConcept);
             await context.SaveChangesAsync();
 
-            var service = new ConceptService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ConceptService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(concept.Id);
             var invalidResult = await service.Get(invalidConcept.Id);
 
@@ -65,9 +65,9 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Concept concept, ConceptRequest request)
+        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Concept concept, ConceptRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -75,32 +75,32 @@ namespace Lern_API.Tests.Services
             await context.Concepts.AddAsync(concept);
             await context.SaveChangesAsync();
 
-            var service = new ConceptService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ConceptService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Update(concept.Id, request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, ConceptRequest request)
+        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, ConceptRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
             
-            var service = new ConceptService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ConceptService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Create(request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Concept concept)
+        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Concept concept)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -108,10 +108,10 @@ namespace Lern_API.Tests.Services
             await context.Concepts.AddAsync(concept);
             await context.SaveChangesAsync();
 
-            var service = new ConceptService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ConceptService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Delete(concept.Id);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
     }
 }

--- a/Lern-API.Tests/Services/CourseServiceShould.cs
+++ b/Lern-API.Tests/Services/CourseServiceShould.cs
@@ -20,7 +20,7 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_Entire_Course_With_Write_Access(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Course course, User user)
+        public async Task Get_Entire_Course_With_Write_Access(Mock<IAuthorizationService> authorizationService, IStateService stateService, Course course, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, course, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
@@ -33,7 +33,7 @@ namespace Lern_API.Tests.Services
             await context.Courses.AddRangeAsync(course);
             await context.SaveChangesAsync();
 
-            var service = new CourseService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new CourseService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(course.Id);
 
             result.Should().BeEquivalentTo(course);
@@ -41,7 +41,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Course_With_A_Valid_Exercise(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Course course, Course invalidCourse, User user)
+        public async Task Get_Course_With_A_Valid_Exercise(Mock<IAuthorizationService> authorizationService, IStateService stateService, Course course, Course invalidCourse, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, It.IsAny<Course>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -56,7 +56,7 @@ namespace Lern_API.Tests.Services
             await context.Courses.AddAsync(invalidCourse);
             await context.SaveChangesAsync();
 
-            var service = new CourseService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new CourseService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(course.Id);
             var invalidResult = await service.Get(invalidCourse.Id);
 
@@ -66,10 +66,10 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Single_Course_Or_Null(IAuthorizationService authorizationService, ISubjectService subjectService, List<Course> entities, Course target)
+        public async Task Get_Single_Course_Or_Null(IAuthorizationService authorizationService, IStateService stateService, List<Course> entities, Course target)
         {
             var context = TestSetup.SetupContext();
-            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, subjectService);
+            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, stateService);
 
             await context.Courses.AddRangeAsync(entities);
             await context.Courses.AddAsync(target);
@@ -84,13 +84,13 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Latest_Version(IAuthorizationService authorizationService, ISubjectService subjectService, List<Course> entities, Course target)
+        public async Task Get_Latest_Version(IAuthorizationService authorizationService, IStateService stateService, List<Course> entities, Course target)
         {
             var request = new CourseRequest();
             request.CloneFrom(target);
 
             var context = TestSetup.SetupContext();
-            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, subjectService);
+            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, stateService);
 
             await context.Courses.AddRangeAsync(entities);
             await context.Courses.AddAsync(target);
@@ -104,7 +104,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Exact_Version(IAuthorizationService authorizationService, ISubjectService subjectService, List<Course> entities, Course target)
+        public async Task Get_Exact_Version(IAuthorizationService authorizationService, IStateService stateService, List<Course> entities, Course target)
         {
             var delta = 1;
 
@@ -116,7 +116,7 @@ namespace Lern_API.Tests.Services
             });
 
             var context = TestSetup.SetupContext();
-            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, subjectService);
+            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, stateService);
 
             await context.Courses.AddRangeAsync(entities);
             await context.Courses.AddAsync(target);
@@ -129,10 +129,10 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Course_Version(IAuthorizationService authorizationService, ISubjectService subjectService, Course entity, CourseRequest request)
+        public async Task Update_Course_Version(IAuthorizationService authorizationService, IStateService stateService, Course entity, CourseRequest request)
         {
             var context = TestSetup.SetupContext();
-            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, subjectService);
+            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, stateService);
 
             await context.Courses.AddAsync(entity);
             await context.SaveChangesAsync();
@@ -150,10 +150,10 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Delete_All_Versions(IAuthorizationService authorizationService, ISubjectService subjectService, List<Course> entities, Course target)
+        public async Task Delete_All_Versions(IAuthorizationService authorizationService, IStateService stateService, List<Course> entities, Course target)
         {
             var context = TestSetup.SetupContext();
-            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, subjectService);
+            var service = new CourseService(context, TestSetup.SetupHttpContext(), authorizationService, stateService);
 
             await context.Courses.AddRangeAsync(entities);
 
@@ -179,9 +179,9 @@ namespace Lern_API.Tests.Services
         
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Course course, CourseRequest request)
+        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Course course, CourseRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -189,32 +189,32 @@ namespace Lern_API.Tests.Services
             await context.Courses.AddAsync(course);
             await context.SaveChangesAsync();
 
-            var service = new CourseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new CourseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Update(course.Id, request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, CourseRequest request)
+        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, CourseRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
             
-            var service = new CourseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new CourseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Create(request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Course course)
+        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Course course)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -222,10 +222,10 @@ namespace Lern_API.Tests.Services
             await context.Courses.AddAsync(course);
             await context.SaveChangesAsync();
 
-            var service = new CourseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new CourseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Delete(course.Id);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
     }
 }

--- a/Lern-API.Tests/Services/DatabaseServiceShould.cs
+++ b/Lern-API.Tests/Services/DatabaseServiceShould.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.Models;
-using Lern_API.Services;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;

--- a/Lern-API.Tests/Services/ExerciseServiceShould.cs
+++ b/Lern-API.Tests/Services/ExerciseServiceShould.cs
@@ -18,7 +18,7 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_Entire_Exercise_With_Write_Access(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Exercise exercise, User user)
+        public async Task Get_Entire_Exercise_With_Write_Access(Mock<IAuthorizationService> authorizationService, IStateService stateService, Exercise exercise, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, exercise, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
@@ -31,7 +31,7 @@ namespace Lern_API.Tests.Services
             await context.Exercises.AddRangeAsync(exercise);
             await context.SaveChangesAsync();
 
-            var service = new ExerciseService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ExerciseService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(exercise.Id);
 
             result.Should().BeEquivalentTo(exercise);
@@ -39,7 +39,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Exercise_With_A_Valid_Question(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Exercise exercise, Exercise invalidExercise, User user)
+        public async Task Get_Exercise_With_A_Valid_Question(Mock<IAuthorizationService> authorizationService, IStateService stateService, Exercise exercise, Exercise invalidExercise, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, It.IsAny<Exercise>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
             
@@ -52,7 +52,7 @@ namespace Lern_API.Tests.Services
             await context.Exercises.AddAsync(invalidExercise);
             await context.SaveChangesAsync();
 
-            var service = new ExerciseService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ExerciseService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(exercise.Id);
             var invalidResult = await service.Get(invalidExercise.Id);
 
@@ -62,9 +62,9 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Exercise exercise, ExerciseRequest request)
+        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Exercise exercise, ExerciseRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -72,32 +72,32 @@ namespace Lern_API.Tests.Services
             await context.Exercises.AddAsync(exercise);
             await context.SaveChangesAsync();
 
-            var service = new ExerciseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ExerciseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Update(exercise.Id, request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, ExerciseRequest request)
+        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, ExerciseRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
             
-            var service = new ExerciseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ExerciseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Create(request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Exercise exercise)
+        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Exercise exercise)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -105,10 +105,10 @@ namespace Lern_API.Tests.Services
             await context.Exercises.AddAsync(exercise);
             await context.SaveChangesAsync();
 
-            var service = new ExerciseService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ExerciseService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Delete(exercise.Id);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
     }
 }

--- a/Lern-API.Tests/Services/ModuleServiceShould.cs
+++ b/Lern-API.Tests/Services/ModuleServiceShould.cs
@@ -18,7 +18,7 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Get_Entire_Module_With_Write_Access(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Module module, User user)
+        public async Task Get_Entire_Module_With_Write_Access(Mock<IAuthorizationService> authorizationService, IStateService stateService, Module module, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, module, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
@@ -31,7 +31,7 @@ namespace Lern_API.Tests.Services
             await context.Modules.AddAsync(module);
             await context.SaveChangesAsync();
 
-            var service = new ModuleService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ModuleService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(module.Id);
 
             result.Should().BeEquivalentTo(module);
@@ -39,7 +39,7 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Get_Module_With_A_Course_And_An_Exercise(Mock<IAuthorizationService> authorizationService, ISubjectService subjectService, Module module, Module invalidModule, User user)
+        public async Task Get_Module_With_A_Course_And_An_Exercise(Mock<IAuthorizationService> authorizationService, IStateService stateService, Module module, Module invalidModule, User user)
         {
             authorizationService.Setup(x => x.HasWriteAccess(user, It.IsAny<Module>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -55,7 +55,7 @@ namespace Lern_API.Tests.Services
             await context.Modules.AddAsync(invalidModule);
             await context.SaveChangesAsync();
 
-            var service = new ModuleService(context, httpContext, authorizationService.Object, subjectService);
+            var service = new ModuleService(context, httpContext, authorizationService.Object, stateService);
             var result = await service.Get(module.Id);
             var invalidResult = await service.Get(invalidModule.Id);
 
@@ -65,9 +65,9 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Module module, ModuleRequest request)
+        public async Task Update_Subject_State_On_Update(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Module module, ModuleRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -75,32 +75,32 @@ namespace Lern_API.Tests.Services
             await context.Modules.AddAsync(module);
             await context.SaveChangesAsync();
 
-            var service = new ModuleService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ModuleService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Update(module.Id, request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, ModuleRequest request)
+        public async Task Update_Subject_State_On_Create(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, ModuleRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
             
-            var service = new ModuleService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ModuleService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Create(request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<ISubjectService> subjectService, Module module)
+        public async Task Update_Subject_State_On_Delete(Mock<IAuthorizationService> authorizationService, Mock<IStateService> stateService, Module module)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -108,10 +108,10 @@ namespace Lern_API.Tests.Services
             await context.Modules.AddAsync(module);
             await context.SaveChangesAsync();
 
-            var service = new ModuleService(context, httpContext, authorizationService.Object, subjectService.Object);
+            var service = new ModuleService(context, httpContext, authorizationService.Object, stateService.Object);
             await service.Delete(module.Id);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
     }
 }

--- a/Lern-API.Tests/Services/ProgressionServiceShould.cs
+++ b/Lern-API.Tests/Services/ProgressionServiceShould.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Lern_API.Models;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
+using Moq;
 using Xunit;
 
 namespace Lern_API.Tests.Services

--- a/Lern-API.Tests/Services/QuestionServiceShould.cs
+++ b/Lern-API.Tests/Services/QuestionServiceShould.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.Helpers.Models;
 using Lern_API.Models;
+using Lern_API.Services;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
 using Lern_API.Tests.Utils;
@@ -18,10 +19,10 @@ namespace Lern_API.Tests.Services
     {
         [Theory]
         [AutoMoqData]
-        public async Task Create_Answers(ISubjectService subjectService, QuestionRequest request)
+        public async Task Create_Answers(IStateService stateService, QuestionRequest request)
         {
             var context = TestSetup.SetupContext();
-            var service = new QuestionService(context, TestSetup.SetupHttpContext(), subjectService);
+            var service = new QuestionService(context, TestSetup.SetupHttpContext(), stateService);
 
             var result = await service.Create(request);
 
@@ -31,10 +32,10 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Delete_Answers(ISubjectService subjectService, Question entity, QuestionRequest request)
+        public async Task Delete_Answers(IStateService stateService, Question entity, QuestionRequest request)
         {
             var context = TestSetup.SetupContext();
-            var service = new QuestionService(context, TestSetup.SetupHttpContext(), subjectService);
+            var service = new QuestionService(context, TestSetup.SetupHttpContext(), stateService);
 
             await context.Questions.AddAsync(entity);
             await context.SaveChangesAsync();
@@ -48,10 +49,10 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Answers(ISubjectService subjectService, Question entity, QuestionRequest request, Answer answer, AnswerRequest answerRequest)
+        public async Task Update_Answers(IStateService stateService, Question entity, QuestionRequest request, Answer answer, AnswerRequest answerRequest)
         {
             var context = TestSetup.SetupContext();
-            var service = new QuestionService(context, TestSetup.SetupHttpContext(), subjectService);
+            var service = new QuestionService(context, TestSetup.SetupHttpContext(), stateService);
             
             answer.QuestionId = entity.Id;
 
@@ -76,9 +77,9 @@ namespace Lern_API.Tests.Services
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Update(Mock<ISubjectService> subjectService, Question question, QuestionRequest request)
+        public async Task Update_Subject_State_On_Update(Mock<IStateService> stateService, Question question, QuestionRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -86,32 +87,32 @@ namespace Lern_API.Tests.Services
             await context.Questions.AddAsync(question);
             await context.SaveChangesAsync();
 
-            var service = new QuestionService(context, httpContext, subjectService.Object);
+            var service = new QuestionService(context, httpContext, stateService.Object);
             await service.Update(question.Id, request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Create(Mock<ISubjectService> subjectService, QuestionRequest request)
+        public async Task Update_Subject_State_On_Create(Mock<IStateService> stateService, QuestionRequest request)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
             
-            var service = new QuestionService(context, httpContext, subjectService.Object);
+            var service = new QuestionService(context, httpContext, stateService.Object);
             await service.Create(request);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
 
         [Theory]
         [AutoMoqData]
-        public async Task Update_Subject_State_On_Delete(Mock<ISubjectService> subjectService, Question question)
+        public async Task Update_Subject_State_On_Delete(Mock<IStateService> stateService, Question question)
         {
-            subjectService.Setup(x => x.UpdateState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
+            stateService.Setup(x => x.UpdateSubjectState(It.IsAny<Guid>(), It.IsAny<CancellationToken>()));
             
             var context = TestSetup.SetupContext();
             var httpContext = TestSetup.SetupHttpContext();
@@ -119,10 +120,10 @@ namespace Lern_API.Tests.Services
             await context.Questions.AddAsync(question);
             await context.SaveChangesAsync();
 
-            var service = new QuestionService(context, httpContext, subjectService.Object);
+            var service = new QuestionService(context, httpContext, stateService.Object);
             await service.Delete(question.Id);
 
-            subjectService.VerifyAll();
+            stateService.VerifyAll();
         }
     }
 }

--- a/Lern-API.Tests/Services/ResultServiceShould.cs
+++ b/Lern-API.Tests/Services/ResultServiceShould.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Lern_API.DataTransferObjects.Requests;
 using Lern_API.Models;
 using Lern_API.Services.Database;
 using Lern_API.Tests.Attributes;
@@ -103,30 +102,6 @@ namespace Lern_API.Tests.Services
             var result = await service.Get(user, question);
 
             result.Should().NotBeNull().And.BeEquivalentTo(entity);
-        }
-
-        [Theory]
-        [AutoMoqData]
-        public async Task Register_Answers(User user, List<Question> questions)
-        {
-            var answers = questions.Select(question => new ResultRequest
-            {
-                QuestionId = question.Id,
-                AnswerId = question.Answers.First().Id
-            }).ToList();
-
-            var context = TestSetup.SetupContext();
-
-            await context.Users.AddAsync(user);
-            await context.Questions.AddRangeAsync(questions);
-            await context.SaveChangesAsync();
-
-            var service = new ResultService(context);
-
-            var result = await service.RegisterAnswers(user, answers);
-
-            result.Should().BeTrue();
-            context.Results.AsEnumerable().Should().HaveCount(answers.Count);
         }
     }
 }

--- a/Lern-API.Tests/Services/StateServiceShould.cs
+++ b/Lern-API.Tests/Services/StateServiceShould.cs
@@ -1,0 +1,439 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Models;
+using Lern_API.Services;
+using Lern_API.Services.Database;
+using Lern_API.Tests.Attributes;
+using Lern_API.Tests.Utils;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Lern_API.Tests.Services
+{
+    public class StateServiceShould
+    {
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Completion_To_100(Mock<IProgressionService> progressionService, Mock<IResultService> resultService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var results = subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                {
+                    QuestionId = question.Id,
+                    AnswerId = question.Answers.First().Id,
+                    UserId = user.Id
+                }))))
+                .Concat(subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Courses.SelectMany(course => course.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                    {
+                        QuestionId = question.Id,
+                        AnswerId = question.Answers.First().Id,
+                        UserId = user.Id
+                    }
+                )))))).ToList();
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(results);
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(results);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeTrue();
+            context.Progressions.First().Completion.Should().Be(100);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Completion_To_50(Mock<IResultService> resultService, Mock<IProgressionService> progressionService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var results = subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                {
+                    QuestionId = question.Id,
+                    AnswerId = question.Answers.First().Id,
+                    UserId = user.Id
+                }))))
+                .Concat(subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Courses.SelectMany(course => course.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                    {
+                        QuestionId = question.Id,
+                        AnswerId = question.Answers.First().Id,
+                        UserId = user.Id
+                    }
+                )))))).ToList();
+
+            results.RemoveRange(0, results.Count / 2);
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(results);
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(results);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeFalse();
+            context.Progressions.First().Completion.Should().BeApproximately(50, 1);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Completion_To_0(Mock<IResultService> resultService, Mock<IProgressionService> progressionService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(new List<Result>());
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeFalse();
+            context.Progressions.First().Completion.Should().Be(0);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Score_To_100(Mock<IResultService> resultService, Mock<IProgressionService> progressionService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var results = subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                {
+                    QuestionId = question.Id,
+                    AnswerId = question.Answers.First(answer => answer.Valid).Id,
+                    UserId = user.Id
+                }))))
+                .Concat(subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Courses.SelectMany(course => course.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                    {
+                        QuestionId = question.Id,
+                        AnswerId = question.Answers.First(answer => answer.Valid).Id,
+                        UserId = user.Id
+                    }
+                )))))).ToList();
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(results);
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(results);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeTrue();
+            context.Progressions.First().Score.Should().Be(100);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Score_To_50(Mock<IResultService> resultService, Mock<IProgressionService> progressionService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var results = subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                {
+                    QuestionId = question.Id,
+                    Question = question,
+                    AnswerId = question.Answers.First(answer => answer.Valid).Id,
+                    UserId = user.Id
+                }))))
+                .Concat(subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Courses.SelectMany(course => course.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                    {
+                        QuestionId = question.Id,
+                        Question = question,
+                        AnswerId = question.Answers.First(answer => answer.Valid).Id,
+                        UserId = user.Id
+                    }
+                )))))).ToList();
+
+            var resultsCount = results.Count;
+
+            for (var i = 0; i < resultsCount / 2; i++)
+            {
+                var currentResult = results.ElementAt(i);
+                currentResult.AnswerId = currentResult.Question.Answers.First(answer => !answer.Valid).Id;
+            }
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(results);
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(results);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeTrue();
+            context.Progressions.First().Score.Should().BeApproximately(50, 1);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Score_To_0(Mock<IResultService> resultService, Mock<IProgressionService> progressionService, User user, Subject subject, List<Result> randomResults)
+        {
+            var progression = new Progression
+            {
+                Subject = subject,
+                SubjectId = subject.Id,
+                User = user,
+                UserId = user.Id,
+                Concept = subject.Modules.First().Concepts.First()
+            };
+
+            randomResults.ForEach(x => x.UserId = user.Id);
+
+            var results = subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                {
+                    QuestionId = question.Id,
+                    AnswerId = question.Answers.First(answer => !answer.Valid).Id,
+                    UserId = user.Id
+                }))))
+                .Concat(subject.Modules.SelectMany(module => module.Concepts.SelectMany(concept => concept.Courses.SelectMany(course => course.Exercises.SelectMany(exercise => exercise.Questions.Select(question => new Result
+                    {
+                        QuestionId = question.Id,
+                        AnswerId = question.Answers.First(answer => !answer.Valid).Id,
+                        UserId = user.Id
+                    }
+                )))))).ToList();
+
+            var context = TestSetup.SetupContext();
+
+            progressionService.Setup(x => x.Exists(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            progressionService.Setup(x => x.Get(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(progression);
+
+            progressionService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Action<DbSet<Progression>>>(), It.IsAny<CancellationToken>()))
+                .Callback((Action<DbSet<Progression>> action, CancellationToken _) =>
+                {
+                    action(context.Progressions);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+            
+            resultService.Setup(x => x.GetAll(user, subject, It.IsAny<CancellationToken>())).ReturnsAsync(results);
+            
+            await context.Users.AddAsync(user);
+            await context.Subjects.AddAsync(subject);
+            await context.Results.AddRangeAsync(results);
+            await context.Results.AddRangeAsync(randomResults);
+            await context.Progressions.AddAsync(progression);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService.Object, resultService.Object);
+
+            var result = await service.UpdateCompletion(user, subject.Id);
+
+            result.Should().BeTrue();
+            context.Progressions.First().Completed.Should().BeTrue();
+            context.Progressions.First().Score.Should().Be(0);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Register_Answers(IProgressionService progressionService, Mock<IResultService> resultService, User user, List<Question> questions)
+        {
+            var answers = questions.Select(question => new ResultRequest
+            {
+                QuestionId = question.Id,
+                AnswerId = question.Answers.First().Id
+            }).ToList();
+
+            var context = TestSetup.SetupContext();
+
+            resultService
+                .Setup(x => x.ExecuteTransaction(It.IsAny<Func<DbSet<Result>, Task>>(), It.IsAny<CancellationToken>()))
+                .Callback((Func<DbSet<Result>, Task> action, CancellationToken _) =>
+                {
+                    action(context.Results);
+                    context.SaveChanges();
+                }).ReturnsAsync(true);
+
+            await context.Users.AddAsync(user);
+            await context.Questions.AddRangeAsync(questions);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService, resultService.Object);
+
+            var result = await service.RegisterAnswers(user, answers);
+
+            result.Should().BeTrue();
+            context.Results.AsEnumerable().Should().HaveCount(answers.Count);
+        }
+        
+        [Theory]
+        [AutoMoqData]
+        public async Task Update_Subject_State(IProgressionService progressionService, IResultService resultService, Subject subject, Subject invalidSubject)
+        {
+            subject.Modules.First().Concepts.First().Exercises.First().Questions.First().Answers.First().Valid = true;
+
+            invalidSubject.Modules.First().Concepts.First().Exercises.First().Questions.First().Answers.ForEach(x => x.Valid = false);
+            invalidSubject.Modules.First().Concepts.First().Courses.Clear();
+
+            var context = TestSetup.SetupContext();
+
+            await context.Subjects.AddAsync(subject);
+            await context.Subjects.AddAsync(invalidSubject);
+            await context.SaveChangesAsync();
+
+            var service = new StateService(context, progressionService, resultService);
+            var result = await service.UpdateSubjectState(subject.Id);
+            var invalidResult = await service.UpdateSubjectState(invalidSubject.Id);
+
+            result.State.Should().Be(SubjectState.Approved);
+            invalidResult.State.Should().Be(SubjectState.Invalid);
+        }
+    }
+}

--- a/Lern-API/Controllers/ResultsController.cs
+++ b/Lern-API/Controllers/ResultsController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Lern_API.DataTransferObjects.Requests;
 using Lern_API.Helpers.JWT;
 using Lern_API.Models;
+using Lern_API.Services;
 using Lern_API.Services.Database;
 using Microsoft.AspNetCore.Mvc;
 
@@ -17,12 +18,14 @@ namespace Lern_API.Controllers
         private readonly IResultService _results;
         private readonly IQuestionService _questions;
         private readonly IExerciseService _exercises;
+        private readonly IStateService _state;
 
-        public ResultsController(IResultService results, IQuestionService questions, IExerciseService exercises)
+        public ResultsController(IResultService results, IQuestionService questions, IExerciseService exercises, IStateService state)
         {
             _results = results;
             _questions = questions;
             _exercises = exercises;
+            _state = state;
         }
         
         /// <summary>
@@ -85,7 +88,7 @@ namespace Lern_API.Controllers
         [HttpPost]
         public async Task<IActionResult> RegisterAnswers(IEnumerable<ResultRequest> answers)
         {
-            var result = await _results.RegisterAnswers(HttpContext.GetUser(), answers, HttpContext.RequestAborted);
+            var result = await _state.RegisterAnswers(HttpContext.GetUser(), answers, HttpContext.RequestAborted);
 
             return result ? Ok() : Forbid();
         }

--- a/Lern-API/DataTransferObjects/Responses/ProgressionResponse.cs
+++ b/Lern-API/DataTransferObjects/Responses/ProgressionResponse.cs
@@ -16,6 +16,8 @@ namespace Lern_API.DataTransferObjects.Responses
         public bool Completed { get; set; }
         [Range(0, 100)]
         public double Completion { get; set; }
+        [Range(0, 100)]
+        public double Score { get; set; }
 
         public ProgressionResponse(Progression progression)
         {

--- a/Lern-API/Filters/SubjectsFilters.cs
+++ b/Lern-API/Filters/SubjectsFilters.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using Lern_API.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lern_API.Filters
+{
+    public static class SubjectsFilters
+    {
+        public static IQueryable<Subject> ValidSubjects(IQueryable<Subject> subjects)
+        {
+            return subjects
+                .Include(subject => subject.Author)
+                .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
+                .ThenInclude(module => module.Concepts.Where(concept =>
+                    concept.Courses.Any() && concept.Exercises.Any(exercise =>
+                        exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
+                .ThenInclude(concept => concept.Courses)
+                .ThenInclude(course => course.Exercises.Where(exercise =>
+                    exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid))))
+                .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
+                .ThenInclude(question => question.Answers)
+                .Include(subject => subject.Modules.Where(module => module.Concepts.Any()))
+                .ThenInclude(module => module.Concepts.Where(concept =>
+                    concept.Courses.Any() && concept.Exercises.Any(exercise =>
+                        exercise.Questions.Any(question => question.Answers.Any(answer => answer.Valid)))))
+                .ThenInclude(concept => concept.Exercises.Where(exercise => exercise.Questions.Any()))
+                .ThenInclude(exercise => exercise.Questions.Where(question => question.Answers.Any(answer => answer.Valid)))
+                .ThenInclude(question => question.Answers)
+                .Where(subject =>
+                    subject.Modules.Any() && subject.Modules.All(module =>
+                        module.Concepts.Any() && module.Concepts.All(concept => concept.Courses.Any() &&
+                                                                                concept.Exercises.Any() &&
+                                                                                concept.Exercises.All(exercise =>
+                                                                                    exercise.Questions.Any() &&
+                                                                                    exercise.Questions.All(question =>
+                                                                                        question.Answers.Any(answer =>
+                                                                                            answer.Valid))
+                                                                                ))));
+        }
+    }
+}

--- a/Lern-API/Migrations/20210616072652_ProgressionScore.Designer.cs
+++ b/Lern-API/Migrations/20210616072652_ProgressionScore.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Lern_API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Lern_API.Migrations
 {
     [DbContext(typeof(LernContext))]
-    partial class LernContextModelSnapshot : ModelSnapshot
+    [Migration("20210616072652_ProgressionScore")]
+    partial class ProgressionScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Lern-API/Migrations/20210616072652_ProgressionScore.cs
+++ b/Lern-API/Migrations/20210616072652_ProgressionScore.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Lern_API.Migrations
+{
+    public partial class ProgressionScore : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Score",
+                table: "Progressions",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Score",
+                table: "Progressions");
+        }
+    }
+}

--- a/Lern-API/Models/Progression.cs
+++ b/Lern-API/Models/Progression.cs
@@ -28,5 +28,7 @@ namespace Lern_API.Models
         public bool Completed { get; set; }
         [ReadOnly(true), Range(0, 100)]
         public double Completion { get; set; }
+        [ReadOnly(true), Range(0, 100)]
+        public double Score { get; set; }
     }
 }

--- a/Lern-API/Services/Database/AbstractDatabaseService.cs
+++ b/Lern-API/Services/Database/AbstractDatabaseService.cs
@@ -9,10 +9,11 @@ namespace Lern_API.Services.Database
     public interface IAbstractDatabaseService<TEntity> where TEntity : class
     {
         Task<T> ExecuteTransaction<T>(Func<DbSet<TEntity>, Task<T>> operations, CancellationToken token = default);
+        Task<bool> ExecuteTransaction(Func<DbSet<TEntity>, Task> operations, CancellationToken token = default);
         Task<T> ExecuteTransaction<T>(Func<DbSet<TEntity>, T> operations, CancellationToken token = default);
         Task<bool> ExecuteTransaction(Action<DbSet<TEntity>> operations, CancellationToken token = default);
         Task<T> ExecuteQuery<T>(Func<IQueryable<TEntity>, Task<T>> query, CancellationToken token = default);
-        T ExecuteQuery<T>(Func<IQueryable<TEntity>, T> query, CancellationToken token = default);
+        T ExecuteQuery<T>(Func<IQueryable<TEntity>, T> query);
     }
 
     public abstract class AbstractDatabaseService<TEntity> : IAbstractDatabaseService<TEntity> where TEntity : class
@@ -32,6 +33,11 @@ namespace Lern_API.Services.Database
         }
 
         public async Task<T> ExecuteTransaction<T>(Func<DbSet<TEntity>, Task<T>> operations, CancellationToken token = default)
+        {
+            return await SafeExecute(operations, token);
+        }
+
+        public async Task<bool> ExecuteTransaction(Func<DbSet<TEntity>, Task> operations, CancellationToken token = default)
         {
             return await SafeExecute(operations, token);
         }
@@ -60,7 +66,7 @@ namespace Lern_API.Services.Database
             }
         }
 
-        public T ExecuteQuery<T>(Func<IQueryable<TEntity>, T> query, CancellationToken token = default)
+        public T ExecuteQuery<T>(Func<IQueryable<TEntity>, T> query)
         {
             try
             {

--- a/Lern-API/Services/Database/ConceptService.cs
+++ b/Lern-API/Services/Database/ConceptService.cs
@@ -17,12 +17,12 @@ namespace Lern_API.Services.Database
     public class ConceptService : DatabaseService<Concept, ConceptRequest>, IConceptService
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly ISubjectService _subjectService;
+        private readonly IStateService _stateService;
 
-        public ConceptService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, ISubjectService subjectService) : base(context, httpContextAccessor)
+        public ConceptService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IStateService stateService) : base(context, httpContextAccessor)
         {
             _authorizationService = authorizationService;
-            _subjectService = subjectService;
+            _stateService = stateService;
         }
 
         protected override IQueryable<Concept> WithDefaultIncludes(DbSet<Concept> set)
@@ -73,7 +73,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Id == result.ModuleId), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result;
         }
@@ -87,7 +87,7 @@ namespace Lern_API.Services.Database
                 return false;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Id == entity.ModuleId), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return true;
         }
@@ -100,7 +100,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Id == result.ModuleId), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result;
         }

--- a/Lern-API/Services/Database/CourseService.cs
+++ b/Lern-API/Services/Database/CourseService.cs
@@ -20,12 +20,12 @@ namespace Lern_API.Services.Database
     public class CourseService : DatabaseService<Course, CourseRequest>, ICourseService
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly ISubjectService _subjectService;
+        private readonly IStateService _stateService;
 
-        public CourseService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, ISubjectService subjectService) : base(context, httpContextAccessor)
+        public CourseService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IStateService stateService) : base(context, httpContextAccessor)
         {
             _authorizationService = authorizationService;
-            _subjectService = subjectService;
+            _stateService = stateService;
         }
 
         protected override IQueryable<Course> WithDefaultIncludes(DbSet<Course> set)
@@ -68,7 +68,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == result.ConceptId)), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result;
         }
@@ -135,7 +135,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == result.Entity.ConceptId)), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result.Entity;
         }
@@ -149,7 +149,7 @@ namespace Lern_API.Services.Database
                 return false;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == entity.ConceptId)), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return true;
         }

--- a/Lern-API/Services/Database/ExerciseService.cs
+++ b/Lern-API/Services/Database/ExerciseService.cs
@@ -17,12 +17,12 @@ namespace Lern_API.Services.Database
     public class ExerciseService : DatabaseService<Exercise, ExerciseRequest>, IExerciseService
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly ISubjectService _subjectService;
+        private readonly IStateService _stateService;
 
-        public ExerciseService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, ISubjectService subjectService) : base(context, httpContextAccessor)
+        public ExerciseService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IStateService stateService) : base(context, httpContextAccessor)
         {
             _authorizationService = authorizationService;
-            _subjectService = subjectService;
+            _stateService = stateService;
         }
 
         protected override IQueryable<Exercise> WithDefaultIncludes(DbSet<Exercise> set)
@@ -60,7 +60,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == result.ConceptId) || module.Concepts.Any(concept => concept.Courses.Any(course => course.Id == result.CourseId))), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result;
         }
@@ -74,7 +74,7 @@ namespace Lern_API.Services.Database
                 return false;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == entity.ConceptId) || module.Concepts.Any(concept => concept.Courses.Any(course => course.Id == entity.CourseId))), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return true;
         }
@@ -87,7 +87,7 @@ namespace Lern_API.Services.Database
                 return null;
 
             var subject = await Context.Subjects.FirstOrDefaultAsync(x => x.Modules.Any(module => module.Concepts.Any(concept => concept.Id == result.ConceptId) || module.Concepts.Any(concept => concept.Courses.Any(course => course.Id == result.CourseId))), token);
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result;
         }

--- a/Lern-API/Services/Database/ModuleService.cs
+++ b/Lern-API/Services/Database/ModuleService.cs
@@ -17,12 +17,12 @@ namespace Lern_API.Services.Database
     public class ModuleService : DatabaseService<Module, ModuleRequest>, IModuleService
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly ISubjectService _subjectService;
+        private readonly IStateService _stateService;
 
-        public ModuleService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, ISubjectService subjectService) : base(context, httpContextAccessor)
+        public ModuleService(LernContext context, IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IStateService stateService) : base(context, httpContextAccessor)
         {
             _authorizationService = authorizationService;
-            _subjectService = subjectService;
+            _stateService = stateService;
         }
 
         protected override IQueryable<Module> WithDefaultIncludes(DbSet<Module> set)
@@ -79,7 +79,7 @@ namespace Lern_API.Services.Database
             if (result == null)
                 return null;
 
-            await _subjectService.UpdateState(result.SubjectId, token);
+            await _stateService.UpdateSubjectState(result.SubjectId, token);
 
             return result;
         }
@@ -92,7 +92,7 @@ namespace Lern_API.Services.Database
             if (!result)
                 return false;
 
-            await _subjectService.UpdateState(entity.SubjectId, token);
+            await _stateService.UpdateSubjectState(entity.SubjectId, token);
 
             return true;
         }
@@ -104,7 +104,7 @@ namespace Lern_API.Services.Database
             if (result == null)
                 return null;
 
-            await _subjectService.UpdateState(result.SubjectId, token);
+            await _stateService.UpdateSubjectState(result.SubjectId, token);
 
             return result;
         }

--- a/Lern-API/Services/Database/ProgressionService.cs
+++ b/Lern-API/Services/Database/ProgressionService.cs
@@ -30,7 +30,7 @@ namespace Lern_API.Services.Database
                 .Include(progression => progression.User);
         }
 
-        public virtual async Task<bool> Create(User user, Subject subject, Concept concept, CancellationToken token = default)
+        public async Task<bool> Create(User user, Subject subject, Concept concept, CancellationToken token = default)
         {
             var final = new Progression
             {
@@ -44,22 +44,22 @@ namespace Lern_API.Services.Database
             return entityEntry?.Entity != null;
         }
 
-        public virtual async Task<bool> Exists(User user, Subject subject, CancellationToken token = default)
+        public async Task<bool> Exists(User user, Subject subject, CancellationToken token = default)
         {
             return await DbSet.AnyAsync(x => x.UserId == user.Id && x.SubjectId == subject.Id, token);
         }
 
-        public virtual async Task<Progression> Get(User user, Subject subject, CancellationToken token = default)
+        public async Task<Progression> Get(User user, Subject subject, CancellationToken token = default)
         {
             return await WithDefaultIncludes(DbSet).FirstOrDefaultAsync(x => x.UserId == user.Id && x.SubjectId == subject.Id, token);
         }
 
-        public virtual async Task<IEnumerable<Progression>> GetAll(User user, CancellationToken token = default)
+        public async Task<IEnumerable<Progression>> GetAll(User user, CancellationToken token = default)
         {
             return await WithDefaultIncludes(DbSet).Where(x => x.UserId == user.Id).ToListAsync(token);
         }
 
-        public virtual async Task<bool> Update(User user, Subject subject, Concept concept, CancellationToken token = default)
+        public async Task<bool> Update(User user, Subject subject, Concept concept, CancellationToken token = default)
         {
             var entry = await Get(user, subject, token);
 

--- a/Lern-API/Services/Database/QuestionService.cs
+++ b/Lern-API/Services/Database/QuestionService.cs
@@ -18,11 +18,11 @@ namespace Lern_API.Services.Database
 
     public class QuestionService : DatabaseService<Question, QuestionRequest>, IQuestionService
     {
-        private readonly ISubjectService _subjectService;
+        private readonly IStateService _stateService;
 
-        public QuestionService(LernContext context, IHttpContextAccessor httpContextAccessor, ISubjectService subjectService) : base(context, httpContextAccessor)
+        public QuestionService(LernContext context, IHttpContextAccessor httpContextAccessor, IStateService stateService) : base(context, httpContextAccessor)
         {
-            _subjectService = subjectService;
+            _stateService = stateService;
         }
 
         protected override IQueryable<Question> WithDefaultIncludes(DbSet<Question> set)
@@ -54,7 +54,7 @@ namespace Lern_API.Services.Database
                 token
             );
 
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result.Entity;
         }
@@ -91,7 +91,7 @@ namespace Lern_API.Services.Database
                 token
             );
 
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return result.Entity;
         }
@@ -110,7 +110,7 @@ namespace Lern_API.Services.Database
                 token
             );
 
-            await _subjectService.UpdateState(subject?.Id ?? default, token);
+            await _stateService.UpdateSubjectState(subject?.Id ?? default, token);
 
             return true;
         }

--- a/Lern-API/Services/Database/ResultService.cs
+++ b/Lern-API/Services/Database/ResultService.cs
@@ -13,7 +13,6 @@ namespace Lern_API.Services.Database
         Task<IEnumerable<Result>> GetAll(User user, Subject subject, CancellationToken token = default);
         Task<IEnumerable<Result>> GetAll(User user, Exercise exercise, CancellationToken token = default);
         Task<Result> Get(User user, Question question, CancellationToken token = default);
-        Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default);
     }
 
     public class ResultService : AbstractDatabaseService<Result>, IResultService
@@ -53,18 +52,6 @@ namespace Lern_API.Services.Database
         public async Task<Result> Get(User user, Question question, CancellationToken token = default)
         {
             return await WithDefaultIncludes(DbSet).FirstOrDefaultAsync(x => x.UserId == user.Id && x.QuestionId == question.Id, token);
-        }
-
-        public async Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default)
-        {
-            var results = answers.Select(answer => new Result
-            {
-                AnswerId = answer.AnswerId,
-                QuestionId = answer.QuestionId,
-                UserId = user.Id
-            }).ToList();
-
-            return await SafeExecute(async set => await set.AddRangeAsync(results, token), token);
         }
     }
 }

--- a/Lern-API/Services/StateService.cs
+++ b/Lern-API/Services/StateService.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lern_API.DataTransferObjects.Requests;
+using Lern_API.Filters;
+using Lern_API.Models;
+using Lern_API.Services.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lern_API.Services
+{
+    public interface IStateService
+    {
+        IQueryable<Subject> AvailableSubjects { get; }
+        Task<Subject> UpdateSubjectState(Guid id, CancellationToken token = default);
+        Task<bool> UpdateCompletion(User user, Guid subjectId, CancellationToken token = default);
+        Task UpdateCompletions(Guid subjectId, CancellationToken token = default);
+        Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default);
+    }
+
+    public class StateService : AbstractDatabaseService<Subject>, IStateService
+    {
+        private readonly IProgressionService _progressionService;
+        private readonly IResultService _resultService;
+
+        public IQueryable<Subject> AvailableSubjects => SubjectsFilters.ValidSubjects(DbSet);
+
+        public StateService(LernContext context, IProgressionService progressionService, IResultService resultService) : base(context)
+        {
+            _progressionService = progressionService;
+            _resultService = resultService;
+        }
+
+        public async Task<bool> UpdateCompletion(User user, Guid subjectId, CancellationToken token = default)
+        {
+            var subject = await AvailableSubjects.FirstOrDefaultAsync(x => x.Id == subjectId, token);
+
+            if (subject == null)
+                return false;
+
+            if (!await _progressionService.Exists(user, subject, token))
+            {
+                var firstModule = subject.Modules.First(x => x.Order == subject.Modules.Min(module => module.Order));
+                var firstConcept = firstModule.Concepts.First(x => x.Order == firstModule.Concepts.Min(concept => concept.Order));
+
+                await _progressionService.Create(user, subject, firstConcept, token);
+            }
+
+            var entry = await _progressionService.Get(user, subject, token);
+            var results = (await _resultService.GetAll(user, subject, token)).ToList();
+
+            var validResultsCount = results.Count(result => result.Answer.Valid);
+            var resultsCount = results.Count;
+            
+            var questionsCount =
+                subject.Modules.Sum(module =>
+                    module.Concepts.Sum(concept =>
+                        concept.Exercises.Sum(exercise => exercise.Questions.Count) + concept.Courses.Sum(course => course.Exercises.Sum(exercise => exercise.Questions.Count))));
+
+            var completion = (resultsCount * 100d) / questionsCount;
+            var score = (validResultsCount * 100d) / questionsCount;
+
+            return await _progressionService.ExecuteTransaction(set =>
+            {
+                entry.Completion = completion;
+                entry.Completed = resultsCount == questionsCount;
+
+                if (entry.Completed)
+                    entry.Score = score;
+                else
+                    entry.Score = 0;
+            }, token);
+        }
+
+        public async Task UpdateCompletions(Guid subjectId, CancellationToken token = default)
+        {
+            var progressions = _progressionService.ExecuteQuery(set => set.Where(x => x.SubjectId == subjectId));
+
+            foreach (var progression in progressions)
+            {
+                await UpdateCompletion(progression.User, subjectId, token);
+            }
+        }
+
+        public async Task<bool> RegisterAnswers(User user, IEnumerable<ResultRequest> answers, CancellationToken token = default)
+        {
+            var results = answers.Select(answer => new Result
+            {
+                AnswerId = answer.AnswerId,
+                QuestionId = answer.QuestionId,
+                UserId = user.Id
+            }).ToList();
+
+            var transaction = await _resultService.ExecuteTransaction(async set => await set.AddRangeAsync(results, token), token);
+
+            if (!transaction)
+                return false;
+
+            var subjects = AvailableSubjects.AsEnumerable().Where(subject => subject.Modules.Any(module =>
+                module.Concepts.Any(concept =>
+                    concept.Exercises.Any(exercise =>
+                        exercise.Questions.Any(question => results.Any(result => result.QuestionId == question.Id))) ||
+                    concept.Courses.Any(course =>
+                        course.Exercises.Any(exercise =>
+                            exercise.Questions.Any(question => results.Any(result => result.QuestionId == question.Id))))
+                    )));
+
+            foreach (var subject in subjects)
+            {
+                await UpdateCompletion(user, subject.Id, token);
+            }
+
+            return true;
+        }
+
+        public async Task<Subject> UpdateSubjectState(Guid id, CancellationToken token = default)
+        {
+            var subject = await DbSet.FindAsync(new object[] { id }, token);
+
+            if (subject == null)
+                return null;
+
+            var stateUpdate = await ExecuteTransaction(_ =>
+            {
+                subject.State = AvailableSubjects.Any(x => x.Id == id)
+                    ? SubjectState.Approved
+                    : SubjectState.Invalid;
+
+                return subject;
+            }, token);
+            
+            if (subject.State != SubjectState.Approved)
+                return subject;
+
+            await UpdateCompletions(subject.Id, token);
+
+            return stateUpdate;
+        }
+    }
+}

--- a/Lern-API/Startup.cs
+++ b/Lern-API/Startup.cs
@@ -137,6 +137,7 @@ namespace Lern_API
             services.AddScoped<IQuestionService, QuestionService>();
             services.AddScoped<IResultService, ResultService>();
             services.AddScoped<IProgressionService, ProgressionService>();
+            services.AddScoped<IStateService, StateService>();
             services.AddScoped<IAuthorizationService, AuthorizationService>();
         }
 


### PR DESCRIPTION
Les routes `GET /api/Progression` et `GET /api/Progression/[subjectId}` renvoient maintenant des informations cohérentes avec l'état de progression réel de l'utilisateur :
 - un champ `completed` (bool) qui représente la complétion du sujet par l'utilisateur
 - un champ `completion` (float de 0 à 100) qui représente le pourcentage de complétion de l'utilisateur
 - un champ `score` (float de 0 à 100) qui représente le pourcentage de bonnes réponses sur le total de réponses données aux exercices du sujet concerné

Doit être mergé après #14 